### PR TITLE
Feature build server script

### DIFF
--- a/server/CMakeLists.txt.user
+++ b/server/CMakeLists.txt.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.8.0, 2019-01-09T16:00:14. -->
+<!-- Written by QtCreator 4.8.0, 2019-01-16T09:20:28. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -355,7 +355,7 @@
     <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
     <value type="QString" key="RunConfiguration.WorkingDirectory"></value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/hyle/Documents/Maestro/build-server-Desktop_Qt_5_11_2_GCC_64bit-Default</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/tmp/QtCreator-rjWUUg/qtc-cmake-CkqNNpqL</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.1">
     <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
@@ -411,7 +411,7 @@
     <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
     <value type="QString" key="RunConfiguration.WorkingDirectory"></value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/hyle/Documents/Maestro/build-server-Desktop_Qt_5_11_2_GCC_64bit-Default</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/tmp/QtCreator-rjWUUg/qtc-cmake-CkqNNpqL</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.2">
     <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
@@ -467,7 +467,7 @@
     <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
     <value type="QString" key="RunConfiguration.WorkingDirectory"></value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/hyle/Documents/Maestro/build-server-Desktop_Qt_5_11_2_GCC_64bit-Default</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/tmp/QtCreator-rjWUUg/qtc-cmake-CkqNNpqL</value>
    </valuemap>
    <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">3</value>
   </valuemap>

--- a/server/buildServer.sh
+++ b/server/buildServer.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+mkdir ./build
+cd build
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
+make
+cp -R ../conf/ .
+mkdir traj
+cp ../traj/0.traj ./traj/127.0.0.1

--- a/server/src/objectcontrol.c
+++ b/server/src/objectcontrol.c
@@ -36,7 +36,7 @@
   -- Defines
   ------------------------------------------------------------*/
 
-#define LOCALHOST "127.0.0.1"
+#define LOCALHOST "192.168.1.101"
 
 #define RECV_MESSAGE_BUFFER 1024
 #define OBJECT_MESS_BUFFER_SIZE 1024


### PR DESCRIPTION
Added a simple bash script which goes through the setup steps currently defined in the Wiki. When you run buildServer.sh, it automatically builds the server (With Debug flags), creates a traj-folder and copies one trajectory file as 127.0.0.1.