### PR TITLE
Changed to only send abort to objectControl in running state

### DIFF
--- a/server/src/systemcontrol.c
+++ b/server/src/systemcontrol.c
@@ -851,7 +851,9 @@ void systemcontrol_task(TimeType *GPSTime, GSDType *GSD)
             SystemControlSendControlResponse(SYSTEM_CONTROL_RESPONSE_CODE_OK, "stop:", ControlResponseBuffer, 0, &ClientSocket, 0);
             break;
         case AbortScenario_0:
-            if(strstr(SystemControlOBCStatesArr[OBCStateU8], "CONNECTED") != NULL || strstr(SystemControlOBCStatesArr[OBCStateU8], "ARMED") != NULL || strstr(SystemControlOBCStatesArr[OBCStateU8], "RUNNING") != NULL)
+            if(strstr(SystemControlOBCStatesArr[OBCStateU8], "RUNNING") != NULL
+                    /* || strstr(SystemControlOBCStatesArr[OBCStateU8], "CONNECTED") != NULL
+                     * || strstr(SystemControlOBCStatesArr[OBCStateU8], "ARMED") != NULL*/ ) // Abort should only be allowed in running state
             {
                 (void)iCommSend(COMM_ABORT,NULL);
                 server_state = SERVER_STATE_IDLE;


### PR DESCRIPTION
...and report state error otherwise (see ISO spec)