### PR TITLE
Logger fix

### DIFF
--- a/server/inc/util.h
+++ b/server/inc/util.h
@@ -690,8 +690,6 @@ typedef enum {
 /*------------------------------------------------------------
   -- Function declarations.
   ------------------------------------------------------------*/
-static void _mkdir(const char *dir);
-
 // DEBUG functions
 void dbg_setdebug(int level);
 int dbg_getdebug(void);


### PR DESCRIPTION
mkdir() does not allow for creation of a folder with a subfolder, Fixed this by adding a check that creates the .log folder if it does not exist. 