### PR TITLE
Feature nicer logger printouts

### DIFF
--- a/server/src/logger.c
+++ b/server/src/logger.c
@@ -53,10 +53,6 @@ static int CountFileRows(FILE *fd);
 /*------------------------------------------------------------
   -- Public functions
   ------------------------------------------------------------*/
-
-void  INThandler(int);
-
-
 void logger_task()
 {
     char pcCommand[100];


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/10436623/54203078-be1dfa00-44d1-11e9-9423-784ec3f24d30.png)



Instead of:

![image](https://user-images.githubusercontent.com/10436623/54203107-d42bba80-44d1-11e9-8614-fa260b557f3a.png)
