### PR TITLE
Made time control set system time

### DIFF
--- a/server/src/timecontrol.c
+++ b/server/src/timecontrol.c
@@ -198,13 +198,15 @@ void timecontrol_task(TimeType * GPSTime, GSDType * GSD, LOG_LEVEL logLevel) {
 
 				if (GPSTime->GPSMillisecondsU64 < INT64_MAX) {
 					struct timespec newSystemTime;
+
 					TimeSetToGPSms(&tv, (int64_t) GPSTime->GPSMillisecondsU64);
 					newSystemTime.tv_sec = tv.tv_sec;
 					newSystemTime.tv_nsec = tv.tv_usec * 1000;
 					if (clock_settime(CLOCK_REALTIME, &newSystemTime) == -1) {
 						switch (errno) {
 						case EPERM:
-							LogMessage(LOG_LEVEL_ERROR, "Unable to set system time - ensure this program has the correct capabilities");
+							LogMessage(LOG_LEVEL_ERROR,
+									   "Unable to set system time - ensure this program has the correct capabilities");
 							break;
 						case EINVAL:
 							LogMessage(LOG_LEVEL_ERROR, "Clock type not supported on this system");
@@ -216,7 +218,8 @@ void timecontrol_task(TimeType * GPSTime, GSDType * GSD, LOG_LEVEL logLevel) {
 					}
 				}
 				else {
-					LogMessage(LOG_LEVEL_ERROR, "Current GPS time exceeds limit and would be interpreted as negative");
+					LogMessage(LOG_LEVEL_ERROR,
+							   "Current GPS time exceeds limit and would be interpreted as negative");
 				}
 			}
 		}


### PR DESCRIPTION
There is a big issue here in that TEServer needs the correct permissions to set the system clock. This can be done through
`setcap CAP_SYS_TIME+eip /path/to/runServer.sh`
or
`setcap CAP_SYS_TIME+ep /path/to/TEServer`
as root.

The problem is that the capabilities are (rightly) removed whenever any of the files are modified. We should include setting file capabilities in a future installation process but for now one needs to remember to give CAP_SYS_TIME capabilities to runServer.sh.

An NTP server implementation on the PiTiPo would also fix this problem (and would also give some nicer properties to the system clock).

PS
Don't run TEServer as root.