### PR TITLE
File download and get directory content

### DIFF
--- a/core/src/systemcontrol.c
+++ b/core/src/systemcontrol.c
@@ -1467,7 +1467,9 @@ void SystemControlFileDownloadResponse(U16 ResponseStatus, C8 * ResponseString,
 		}
 
 		//SystemControlSendBytes(Data, n + 4, Sockfd, 0);
-		UtilSendTCPData("System Control", Data, MSCP_RESPONSE_DATALENGTH_BYTES + MSCP_RESPONSE_STATUS_CODE_BYTES + strlen(ResponseString), Sockfd, 0);
+		UtilSendTCPData("System Control", Data,
+						MSCP_RESPONSE_DATALENGTH_BYTES + MSCP_RESPONSE_STATUS_CODE_BYTES +
+						strlen(ResponseString), Sockfd, 0);
 	}
 	else
 		LogMessage(LOG_LEVEL_ERROR, "Response data more than %d bytes!", SYSTEM_CONTROL_SEND_BUFFER_SIZE);


### PR DESCRIPTION
Sending 4 bytes, after first MSCP response, containing the length of the file. The string SubDownload file is not sent.