### PR TITLE
Invalid `const char *` manipulation fix

### DIFF
--- a/core/src/journalcontrol.cpp
+++ b/core/src/journalcontrol.cpp
@@ -325,8 +325,7 @@ int generateOutputJournal(std::unordered_set<Journal> &journals) {
 	std::vector<JournalFileSection> inputFiles;
 	for (const auto &journal : journals) {
 		for (const fs::path &file : journal.containedFiles) {
-			inputFiles.emplace_back();
-			JournalFileSection &section = inputFiles.back();
+			JournalFileSection &section = inputFiles.emplace_back();
 			section.path = file;
 			section.istrm.open(file);
 			if (section.istrm.is_open()) {


### PR DESCRIPTION
The journal functions attempts to manipulate the data of a `std::string` by accessing and setting the underlying `char *`. Turns out that the underlying array can only be returned as a `const char *`, which makes it hard to manipulate ([link to documentation](http://www.cplusplus.com/reference/string/string/data/)). My compiler saw this and did not compile unless this was fixed, so I added these changes to help fix the problem.

What is strange however is that on some computers, the old code will compile without a problem, which is very strange. I believe it might have something to do with backwards compatibility to C in some way ([ref to StackOverflow discussion](https://stackoverflow.com/questions/19319244/passing-a-const-char-to-foochar)). I got @eriadam36 to compile `dev` as it stood before these changes were applied without problem. Also my home ubuntu computer can compile the same code Adam has. So there is a strange problem somewhere, which might have consequences in the future since potential problems can be overlooked. 