### PR TITLE
Send two transgression monr

### DIFF
--- a/core/integration-tests/905-geofenceTransgression.py
+++ b/core/integration-tests/905-geofenceTransgression.py
@@ -109,7 +109,7 @@ def geofenceTransgressionTest():
     obj.MONR(transmitter_id=objID,position=testPts[4])
     transgressionTime = time.time()
     time.sleep(0.01)
-    # Report another MONR outside geofence
+    # Report another MONR outside geofence TODO: remove
     obj.MONR(transmitter_id=objID,position=testPts[4])
     time.sleep(0.01)
     
@@ -140,4 +140,3 @@ if __name__ == "__main__":
             core.stop()
         if obj:
             obj.shutdown()
-


### PR DESCRIPTION
On the virtual machine currently running our Jenkins tests there seems to be some timing issue causing a single transgression monr to sometimes not trigger Abort. 