### PR TITLE
Feature bts module read objectfile

### DIFF
--- a/modules/BackToStart/src/main.cpp
+++ b/modules/BackToStart/src/main.cpp
@@ -36,7 +36,7 @@ int main()
 			break;
 		case COMM_OBC_STATE:
 			break;
-		case COMM_CONNECT:
+		case COMM_INIT:
 			try {
 				loadObjectFiles();
 			} catch (std::invalid_argument& e) {


### PR DESCRIPTION
NATT-31:
Read configuration for turning radius & max speed of object to turn for BTS
DoD: Object file can be read from existing object file reading function.

The BTS module is currently just printing out the values of turning radius and max speed (if available in the .opro) on COMM_CONNECT. To test the command from GUC Back To Start button, you need to enter remote control mode since system control will only pass this command if remote control on. Not sure how the implementation should be done in the end, but I did this to be able to test my tickets.

This branch combines:
- Jespers branch feature_backToStart
- My other PR feature_objectfile_changes_for_BTS

To test add to .opro:
maxSpeed=720 
turningRadius=10.4
