### PR TITLE
Feature per object sub pub

### DIFF
--- a/common/module.hpp
+++ b/common/module.hpp
@@ -113,7 +113,8 @@ class Module : public rclcpp::Node {
 	virtual void onDataDictMessage(const ROSChannels::DataDictionary::message_type::SharedPtr){};
 	virtual void onOSEMMessage(const ROSChannels::Init::message_type::SharedPtr){}; // TODO remove
 	virtual void onASPMessage(const std_msgs::msg::Empty::SharedPtr){}; // TODO once channel defined swap type
-	virtual void onTrajMessage(const std_msgs::msg::Empty::SharedPtr){}; // TODO once channel defined swap type
+	virtual void onTrajectoryMessage(const ROSChannels::Trajectory::message_type::SharedPtr, uint32_t){};
+	virtual void onMonitorMessage(const ROSChannels::Monitor::message_type::SharedPtr, uint32_t){};
 	virtual void onTrajToSupMessage(const std_msgs::msg::Empty::SharedPtr){}; // TODO once channel defined swap type
 	virtual void onTrajFromSupMessage(const std_msgs::msg::Empty::SharedPtr){}; // TODO once channel defined swap type
 	virtual void onAllClearMessage(const ROSChannels::AllClear::message_type::SharedPtr){};

--- a/common/roschannel.hpp
+++ b/common/roschannel.hpp
@@ -3,7 +3,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/empty.hpp>
 #include <std_msgs/msg/u_int8.hpp>
-#include <maestro_interfaces/msg/object_id_array.hpp>
 #include <std_msgs/msg/int8.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <nav_msgs/msg/path.hpp>
@@ -18,6 +17,7 @@
 #include "maestro_interfaces/msg/manoeuvre_command.hpp"
 #include "maestro_interfaces/msg/control_signal_percentage.hpp"
 #include "maestro_interfaces/msg/trigger_event.hpp"
+#include "maestro_interfaces/msg/object_id_array.hpp"
 
 namespace ROSChannels {
 
@@ -452,18 +452,25 @@ namespace Monitor {
 
     class Pub : public BasePub<message_type> {
     public:
-        Pub(rclcpp::Node& node, const rclcpp::QoS& qos = defaultQoS) : BasePub<message_type>(node, topicName, qos) {}
+        const uint32_t objectId;
+        Pub(rclcpp::Node& node, const uint32_t id, const rclcpp::QoS& qos = defaultQoS) : 
+            objectId(id),
+            BasePub<message_type>(node, "object_" + std::to_string(id) + "/" + topicName, qos) {}
     };
 
     class Sub : public BaseSub<message_type> {
     public:
-        Sub(rclcpp::Node& node, std::function<void(const message_type::SharedPtr)> callback, const rclcpp::QoS& qos = defaultQoS) : BaseSub<message_type>(node, topicName, callback, qos) {}
+        const uint32_t objectId;
+        Sub(rclcpp::Node& node, const uint32_t id, std::function<void(const message_type::SharedPtr)> callback, const rclcpp::QoS& qos = defaultQoS) : 
+            objectId(id),
+            BaseSub<message_type>(node, "object_" + std::to_string(id) + "/" + topicName, callback, qos) {}
     };
 }
 
 namespace ObjectsConnected {
     const std::string topicName = "objects_connected";
     using message_type = maestro_interfaces::msg::ObjectIdArray;
+    const rclcpp::QoS defaultQoS = rclcpp::QoS(rclcpp::KeepAll());
 
     class Pub : public BasePub<message_type> {
     public:
@@ -497,12 +504,18 @@ namespace Trajectory {
 
     class Pub : public BasePub<message_type> {
     public:
-        Pub(rclcpp::Node& node, const uint32_t objectId) : BasePub<message_type>(node, topicName + "/object" + std::to_string(objectId)) {}
+        const uint32_t objectId;
+        Pub(rclcpp::Node& node, const uint32_t id) :
+            objectId(id),
+            BasePub<message_type>(node, "object_" + std::to_string(id) + "/" + topicName) {}
     };
 
     class Sub : public BaseSub<message_type> {
     public:
-        Sub(rclcpp::Node& node, const uint32_t objectId, std::function<void(const message_type::SharedPtr)> callback) : BaseSub<message_type>(node, topicName + "/" + std::to_string(objectId), callback) {}
+        const uint32_t objectId;
+        Sub(rclcpp::Node& node, const uint32_t id, std::function<void(const message_type::SharedPtr)> callback) : 
+            objectId(id),
+            BaseSub<message_type>(node, "object_" + std::to_string(id) + "/" + topicName, callback) {}
     };
 }
 } // namespace ROSChannels

--- a/launch/maestro_launch.py
+++ b/launch/maestro_launch.py
@@ -24,12 +24,13 @@ def generate_launch_description():
             namespace='maestro',
             executable='object_control',
             name='object_control'
+            #,prefix="xterm -e gdb --args" #Useful for debugging
         ),
         Node(
             package='maestro',
             namespace='maestro',
-            executable='trajectory_streamer',
-            name='trajectory_streamer'
+            executable='trajectorylet_streamer',
+            name='trajectorylet_streamer'
         ),
         #Node(
         #    package='maestro',

--- a/modules/ObjectControl/CMakeLists.txt
+++ b/modules/ObjectControl/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
-#set(CMAKE_BUILD_TYPE Debug)
+
 
 project(object_control)
 

--- a/modules/ObjectControl/CMakeLists.txt
+++ b/modules/ObjectControl/CMakeLists.txt
@@ -4,10 +4,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+#set(CMAKE_BUILD_TYPE Debug)
+
 project(object_control)
 
 find_package(rclcpp REQUIRED)
 find_package(maestro_interfaces REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 
@@ -63,6 +66,7 @@ target_link_libraries(${OBJECT_CONTROL_TARGET}
 ament_target_dependencies(${OBJECT_CONTROL_TARGET}
   rclcpp
   std_msgs
+  nav_msgs
   maestro_interfaces
   tf2
 )

--- a/modules/ObjectControl/inc/objectcontrol.hpp
+++ b/modules/ObjectControl/inc/objectcontrol.hpp
@@ -153,8 +153,8 @@ public:
 
 	[[deprecated("Avoid referring to objects by IP")]]
 	uint32_t getVehicleIDByIP(const in_addr_t& ip) {
-		auto res = std::find_if(objects.begin(), objects.end(), [&](const std::pair<const uint32_t,TestObject>& elem){
-			return elem.second.getObjectConfig().getIP() == ip;
+		auto res = std::find_if(objects.begin(), objects.end(), [&](const std::pair<const uint32_t,std::shared_ptr<TestObject>>& elem){
+			return elem.second->getObjectConfig().getIP() == ip;
 		});
 		return res->first;
 	}
@@ -194,12 +194,13 @@ private:
 	void onRemoteControlEnableMessage(const ROSChannels::RemoteControlEnable::message_type::SharedPtr) override;
 	void onRemoteControlDisableMessage(const ROSChannels::RemoteControlDisable::message_type::SharedPtr) override;
 	void onControlSignalMessage(const ROSChannels::ControlSignal::message_type::SharedPtr) override;
+	void onTrajectoryMessage(const ROSChannels::Trajectory::message_type::SharedPtr,const uint32_t) override;
 
 	using clock = std::chrono::steady_clock;
 
 	ControlMode controlMode;
 	ObjectControlState* state;					//!< State of module
-	std::map<uint32_t,TestObject> objects;		//!< List of configured test participants
+	std::map<uint32_t,std::shared_ptr<TestObject>> objects;		//!< List of configured test participants
 	std::map<uint32_t,ObjectListener> objectListeners;
 	std::map<uint16_t,std::function<void()>> storedActions;
 	std::mutex monitorTimeMutex;
@@ -227,7 +228,6 @@ private:
 
 	ROSChannels::Failure::Pub failurePub;					//!< Publisher to scenario failure reports
 	ROSChannels::Abort::Pub scnAbortPub;					//!< Publisher to scenario abort reports
-	ROSChannels::Monitor::Pub monitorPub;					//!< Publisher to monitor data
 	ROSChannels::ObjectsConnected::Pub objectsConnectedPub;	//!< Publisher to report connected objects
 	//! Connection methods
 	//! \brief Initiate a thread-based connection attempt. Threads are detached after start,
@@ -243,7 +243,7 @@ private:
 
 	//! \brief Establishe a connection to a specified object, and check the first
 	//!			MONR state. This is a blocking method.
-	void connectToObject(TestObject& obj, std::shared_future<void>& connStopReq);
+	void connectToObject(std::shared_ptr<TestObject> obj, std::shared_future<void>& connStopReq);
 
 	void startListeners();
 	void notifyObjectsConnected();

--- a/modules/ObjectControl/inc/objectlistener.hpp
+++ b/modules/ObjectControl/inc/objectlistener.hpp
@@ -13,12 +13,15 @@ class ObjectControlState;
 class ObjectListener : public Loggable
 {
 public:
-	ObjectListener(ObjectControl*, TestObject*, ROSChannels::Monitor::Pub&, rclcpp::Logger);
+	ObjectListener(
+		ObjectControl*,
+		std::shared_ptr<TestObject>,
+		rclcpp::Logger
+	);
 	~ObjectListener();
 private:
-	TestObject* obj;
+	std::shared_ptr<TestObject> obj;
 	ObjectControl* handler;
-	ROSChannels::Monitor::Pub& monitorChannel;
 	std::thread listener;
 
 	void listen();

--- a/modules/ObjectControl/src/main.cpp
+++ b/modules/ObjectControl/src/main.cpp
@@ -1,10 +1,9 @@
-#include "util.h"
 #include "objectcontrol.hpp"
 
 int main(int argc, char **argv) {
 	rclcpp::init(argc,argv);
-	auto rk = std::make_shared<ObjectControl>();
-	rclcpp::spin(rk);
+	auto obc = std::make_shared<ObjectControl>();
+	rclcpp::spin(obc);
 	rclcpp::shutdown();
 
 	return 0;

--- a/modules/ObjectControl/src/objectcontrol.cpp
+++ b/modules/ObjectControl/src/objectcontrol.cpp
@@ -8,7 +8,6 @@
 #include <thread>
 #include <dirent.h>
 #include <exception>
-#include <string> 
 
 #include "state.hpp"
 #include "util.h"
@@ -510,13 +509,11 @@ void ObjectControl::connectToObject(
 			try {
 				obj->establishConnection(connStopReq);
 				obj->sendSettings();
-				// VJCOM: start object lifecycle node here
 			}
 			catch (std::runtime_error& e) {
 				RCLCPP_ERROR(get_logger(), "Connection attempt for object %u failed: %s",
 						   obj->getTransmitterID(), e.what());
 				obj->disconnect();
-				// VJCOM: Stop lifecycle nodes here
 				return;
 				// TODO connection failed event?
 			}
@@ -577,7 +574,6 @@ void ObjectControl::connectToObject(
 						   obj->getTransmitterID(), e.what());
 				obj->disconnect();
 				// TODO: connection failed event?
-				// VJCOM: Stop lifecycle nodes here
 			}
 		}
 	}
@@ -585,7 +581,6 @@ void ObjectControl::connectToObject(
 		RCLCPP_ERROR(get_logger(), "Bad connection attempt for object %u: %s",
 				   obj->getTransmitterID(), e.what());
 		obj->disconnect();
-		// VJCOM: Stop lifecycle nodes here
 		// TODO: connection failed event?
 	}
 };

--- a/modules/ObjectControl/src/objectcontrol.cpp
+++ b/modules/ObjectControl/src/objectcontrol.cpp
@@ -17,7 +17,6 @@
 #include "objectcontrol.hpp"
 
 using std::placeholders::_1;
-using std::placeholders::_2;
 using namespace ROSChannels;
 
 ObjectControl::ObjectControl()
@@ -280,14 +279,7 @@ void ObjectControl::loadObjectFiles() {
 			catch (std::invalid_argument& e) {
 				RCLCPP_ERROR(get_logger(), e.what());
 				errors.push_back(e);
-			}
-			//auto monrPub = ROSChannels::Monitor::Pub(*this,object.getTransmitterID());
-			//auto trajSub = ROSChannels::Trajectory::Sub(*this,object.getTransmitterID());
-			//monrPubs[object.getTransmitterID()]=monrPub;
-			//trajSubs[object.getTransmitterID()]=trajSub;
-			//object.setTrajSub()
-			//object.setMonrPub()
-			
+			}			
 		}
 	}
 

--- a/modules/ObjectControl/src/objectcontrol.cpp
+++ b/modules/ObjectControl/src/objectcontrol.cpp
@@ -8,6 +8,7 @@
 #include <thread>
 #include <dirent.h>
 #include <exception>
+#include <string> 
 
 #include "state.hpp"
 #include "util.h"
@@ -17,6 +18,7 @@
 #include "objectcontrol.hpp"
 
 using std::placeholders::_1;
+using std::placeholders::_2;
 using namespace ROSChannels;
 
 ObjectControl::ObjectControl()
@@ -36,7 +38,6 @@ ObjectControl::ObjectControl()
 	scnRemoteControlDisableSub(*this, std::bind(&ObjectControl::onRemoteControlDisableMessage, this, _1)),
 	failurePub(*this),
 	scnAbortPub(*this),
-	monitorPub(*this),
 	objectsConnectedPub(*this)
 {
 	int queueSize=0;
@@ -94,9 +95,9 @@ void ObjectControl::handleActionConfigurationCommand(
 	this->state->settingModificationRequested(*this);
 	if (action.command == ACTION_PARAMETER_VS_SEND_START) {
 		RCLCPP_INFO(get_logger(), "Configuring delayed start for object %u", action.objectID);
-		objects.at(action.objectID).setTriggerStart(true);
+		objects.at(action.objectID)->setTriggerStart(true);
 		this->storedActions[action.actionID] = std::bind(&TestObject::sendStart,
-														 &objects.at(action.objectID));
+														 objects.at(action.objectID));
 	}
 }
 
@@ -221,17 +222,21 @@ void ObjectControl::onRemoteControlDisableMessage(const RemoteControlDisable::me
 
 void ObjectControl::onControlSignalMessage(const ControlSignal::message_type::SharedPtr csp){
 	try{
-		objects.at(csp->maestro_header.object_id).sendControlSignal(csp);
+		objects.at(csp->maestro_header.object_id)->sendControlSignal(csp);
 	}
 	catch(const std::exception& e){
 		RCLCPP_ERROR(get_logger(), "Failed to translate/send Control Signal Percentage: %s", e.what());
 	}
 }
 
+void ObjectControl::onTrajectoryMessage(const Trajectory::message_type::SharedPtr trajlet,uint32_t id){
+	objects.at(id)->setLastReceivedTrajectory(trajlet);
+}
+
 void ObjectControl::loadScenario() {
 	this->loadObjectFiles();
-	std::for_each(objects.begin(), objects.end(), [] (std::pair<const uint32_t, TestObject> &o) {
-		auto data = o.second.getAsObjectData();
+	std::for_each(objects.begin(), objects.end(), [] (std::pair<const uint32_t, std::shared_ptr<TestObject>> &o) {
+		auto data = o.second->getAsObjectData();
 		DataDictionarySetObjectData(&data);
 	});
 }
@@ -250,21 +255,26 @@ void ObjectControl::loadObjectFiles() {
 	for (const auto& entry : fs::directory_iterator(objectDir)) {
 		if (fs::is_regular_file(entry.status())) {
 			const auto inputFile = entry.path();
-			TestObject object(get_logger());
+			ObjectConfig conf;
 			try {
-				object.parseConfigurationFile(entry.path());
-
-				RCLCPP_INFO(get_logger(), "Loaded configuration: %s", object.toString().c_str());
+				conf.parseConfigurationFile(inputFile);
+				uint32_t id = conf.getTransmitterID();
+				RCLCPP_INFO(get_logger(), "Loaded configuration: %s", conf.toString().c_str());
 				// Check preexisting
-				auto foundObject = objects.find(object.getTransmitterID());
+				auto foundObject = objects.find(id);
 				if (foundObject == objects.end()) {
-					objects.emplace(object.getTransmitterID(), std::move(object));
+					// Create sub and pub as unique ptrs, when TestObject is destroyed, these get destroyed too.
+					auto trajletSub = std::make_shared<Trajectory::Sub>(*this,id,std::bind(&ObjectControl::onTrajectoryMessage,this,_1,id));
+					auto monrPub = std::make_shared<Monitor::Pub>(*this,id);
+					std::shared_ptr<TestObject> object = std::make_shared<TestObject>(get_logger(),trajletSub,monrPub);
+					object->parseConfigurationFile(inputFile);
+					objects.emplace(id, object);
 				}
 				else {
-					auto badID = object.getTransmitterID();
+					auto badID = conf.getTransmitterID();
 					std::string errMsg = "Duplicate object ID " + std::to_string(badID)
-							+ " detected in files " + objects.at(badID).getTrajectoryFileName()
-							+ " and " + object.getTrajectoryFileName();
+							+ " detected in files " + objects.at(badID)->getTrajectoryFileName()
+							+ " and " + conf.getTrajectoryFileName();
 					throw std::invalid_argument(errMsg);
 				}
 			}
@@ -272,16 +282,23 @@ void ObjectControl::loadObjectFiles() {
 				RCLCPP_ERROR(get_logger(), e.what());
 				errors.push_back(e);
 			}
+			//auto monrPub = ROSChannels::Monitor::Pub(*this,object.getTransmitterID());
+			//auto trajSub = ROSChannels::Trajectory::Sub(*this,object.getTransmitterID());
+			//monrPubs[object.getTransmitterID()]=monrPub;
+			//trajSubs[object.getTransmitterID()]=trajSub;
+			//object.setTrajSub()
+			//object.setMonrPub()
+			
 		}
 	}
 
 	// Fix injector ID maps - reverse their direction
 	for (const auto& id : getVehicleIDs()) {
-		auto injMap = objects.at(id).getObjectConfig().getInjectionMap();
+		auto injMap = objects.at(id)->getObjectConfig().getInjectionMap();
 		for (const auto& sourceID : injMap.sourceIDs) {
-			auto conf = objects.at(sourceID).getObjectConfig();
+			auto conf = objects.at(sourceID)->getObjectConfig();
 			conf.addInjectionTarget(id);
-			objects.at(sourceID).setObjectConfig(conf);
+			objects.at(sourceID)->setObjectConfig(conf);
 		}
 	}
 	
@@ -298,7 +315,7 @@ void ObjectControl::loadObjectFiles() {
 
 uint32_t ObjectControl::getAnchorObjectID() const {
 	for (auto& object : objects) {
-		if (object.second.isAnchor()) {
+		if (object.second->isAnchor()) {
 			return object.first;
 		}
 	}
@@ -307,13 +324,13 @@ uint32_t ObjectControl::getAnchorObjectID() const {
 
 ObjectMonitorType ObjectControl::getLastAnchorData() const {
 	auto anchorID = getAnchorObjectID();
-	return objects.at(anchorID).getLastMonitorData();
+	return objects.at(anchorID)->getLastMonitorData();
 }
 
 std::map<uint32_t,ObjectStateType> ObjectControl::getObjectStates() const {
 	std::map<uint32_t, ObjectStateType> retval;
 	for (const auto& elem : objects) {
-		retval[elem.first] = elem.second.getState();
+		retval[elem.first] = elem.second->getState();
 	}
 	return retval;
 }
@@ -325,10 +342,10 @@ void ObjectControl::transformScenarioRelativeTo(
 			// Skip for now TODO also here - maybe?
 			continue;
 		}
-		auto traj = objects.at(id).getTrajectory();
-		auto relTraj = traj.relativeTo(objects.at(objectID).getTrajectory());
+		auto traj = objects.at(id)->getTrajectory();
+		auto relTraj = traj.relativeTo(objects.at(objectID)->getTrajectory());
 
-		objects.at(id).setTrajectory(relTraj);
+		objects.at(id)->setTrajectory(relTraj);
 	}
 }
 
@@ -370,19 +387,19 @@ void ObjectControl::disconnectObjects() {
 	}
 	objectListeners.clear();
 	for (const auto id : getVehicleIDs()) {
-		objects.at(id).disconnect();
+		objects.at(id)->disconnect();
 	}
 }
 
 void ObjectControl::disconnectObject(
 		const uint32_t id) {
-	objects.at(id).disconnect();
+	objects.at(id)->disconnect();
 	objectListeners.erase(id);
 }
 
 void ObjectControl::uploadObjectConfiguration(
 		const uint32_t id) {
-	objects.at(id).sendSettings();
+	objects.at(id)->sendSettings();
 }
 
 void ObjectControl::startSafetyThread() {
@@ -403,12 +420,12 @@ void ObjectControl::heartbeat() {
 
 		// Check time since MONR for all objects
 		for (const auto& id : getVehicleIDs()) {
-			if (objects.at(id).isConnected()) {
-				auto diff = objects.at(id).getTimeSinceLastMonitor();
-				if (diff > objects.at(id).getMaxAllowedMonitorPeriod()) {
+			if (objects.at(id)->isConnected()) {
+				auto diff = objects.at(id)->getTimeSinceLastMonitor();
+				if (diff > objects.at(id)->getMaxAllowedMonitorPeriod()) {
 					RCLCPP_WARN(get_logger(), "MONR timeout for object %u: %d ms > %d ms", id,
-							   diff.count(), objects.at(id).getMaxAllowedMonitorPeriod().count());
-					objects.at(id).disconnect();
+							   diff.count(), objects.at(id)->getMaxAllowedMonitorPeriod().count());
+					objects.at(id)->disconnect();
 					this->state->disconnectedFromObject(*this, id);
 				}
 			}
@@ -417,13 +434,13 @@ void ObjectControl::heartbeat() {
 		// Send heartbeat
 		for (const auto& id : getVehicleIDs()) {
 			try {
-				if (objects.at(id).isConnected()) {
-					objects.at(id).sendHeartbeat(this->state->asControlCenterStatus());
+				if (objects.at(id)->isConnected()) {
+					objects.at(id)->sendHeartbeat(this->state->asControlCenterStatus());
 				}
 			}
 			catch (std::invalid_argument& e) {
 				RCLCPP_WARN(get_logger(), e.what());
-				objects.at(id).disconnect();
+				objects.at(id)->disconnect();
 				this->state->disconnectedFromObject(*this, id);
 			}
 		}
@@ -454,15 +471,15 @@ OsiHandler::LocalObjectGroundTruth_t ObjectControl::buildOSILocalGroundTruth(
 }
 
 void ObjectControl::injectObjectData(const MonitorMessage &monr) {
-	if (!objects.at(monr.first).getObjectConfig().getInjectionMap().targetIDs.empty()) {
+	if (!objects.at(monr.first)->getObjectConfig().getInjectionMap().targetIDs.empty()) {
 		std::chrono::system_clock::time_point ts;
 		auto secs = std::chrono::seconds(monr.second.timestamp.tv_sec);
 		auto usecs = std::chrono::microseconds(monr.second.timestamp.tv_usec);
 		ts += secs + usecs;
 		auto osiGtData = buildOSILocalGroundTruth(monr);
-		for (const auto& targetID : objects.at(monr.first).getObjectConfig().getInjectionMap().targetIDs) {
-			if (objects.at(targetID).isOsiCompatible()) {
-				objects.at(targetID).sendOsiData(osiGtData, objects.at(targetID).getProjString(), ts);
+		for (const auto& targetID : objects.at(monr.first)->getObjectConfig().getInjectionMap().targetIDs) {
+			if (objects.at(targetID)->isOsiCompatible()) {
+				objects.at(targetID)->sendOsiData(osiGtData, objects.at(targetID)->getProjString(), ts);
 			}
 		}
 	}
@@ -473,7 +490,7 @@ void ObjectControl::startListeners() {
 	RCLCPP_DEBUG(get_logger(), "Starting listeners");
 	objectListeners.clear();
 	for (const auto& id : getVehicleIDs()) {
-		objectListeners.try_emplace(id, this, &objects.at(id), monitorPub, get_logger());
+		objectListeners.try_emplace(id, this, objects.at(id), get_logger());
 	}
 }
 
@@ -484,20 +501,22 @@ void ObjectControl::notifyObjectsConnected() {
 }
 
 void ObjectControl::connectToObject(
-		TestObject &obj,
+		std::shared_ptr<TestObject> obj,
 		std::shared_future<void> &connStopReq) {
 	constexpr int maxConnHeabs = 10;
 	constexpr int maxConnMonrs = 10;
 	try {
-		if (!obj.isConnected()) {
+		if (!obj->isConnected()) {
 			try {
-				obj.establishConnection(connStopReq);
-				obj.sendSettings();
+				obj->establishConnection(connStopReq);
+				obj->sendSettings();
+				// VJCOM: start object lifecycle node here
 			}
 			catch (std::runtime_error& e) {
 				RCLCPP_ERROR(get_logger(), "Connection attempt for object %u failed: %s",
-						   obj.getTransmitterID(), e.what());
-				obj.disconnect();
+						   obj->getTransmitterID(), e.what());
+				obj->disconnect();
+				// VJCOM: Stop lifecycle nodes here
 				return;
 				// TODO connection failed event?
 			}
@@ -509,9 +528,9 @@ void ObjectControl::connectToObject(
 					ObjectStateType objState = OBJECT_STATE_UNKNOWN;
 					auto nextSendTime = std::chrono::system_clock::now();
 					try {
-						obj.sendHeartbeat(this->state->asControlCenterStatus());
+						obj->sendHeartbeat(this->state->asControlCenterStatus());
 						nextSendTime += heartbeatPeriod;
-						objState = obj.getState(true, heartbeatPeriod);
+						objState = obj->getState(true, heartbeatPeriod);
 					} catch (std::runtime_error& e) {
 						if (connectionHeartbeats-- > 0) {
 							std::this_thread::sleep_until(nextSendTime);
@@ -524,67 +543,69 @@ void ObjectControl::connectToObject(
 					switch (objState) {
 					case OBJECT_STATE_ARMED:
 					case OBJECT_STATE_REMOTE_CONTROL:
-						RCLCPP_INFO(get_logger(), "Connected to armed object ID %u", obj.getTransmitterID());
-						this->state->connectedToArmedObject(*this, obj.getTransmitterID());
+						RCLCPP_INFO(get_logger(), "Connected to armed object ID %u", obj->getTransmitterID());
+						this->state->connectedToArmedObject(*this, obj->getTransmitterID());
 						break;
 					case OBJECT_STATE_ABORTING:
 					case OBJECT_STATE_POSTRUN:
 					case OBJECT_STATE_RUNNING:
-						RCLCPP_INFO(get_logger(), "Connected to running object ID %u", obj.getTransmitterID());
-						this->state->connectedToLiveObject(*this, obj.getTransmitterID());
+						RCLCPP_INFO(get_logger(), "Connected to running object ID %u", obj->getTransmitterID());
+						this->state->connectedToLiveObject(*this, obj->getTransmitterID());
 						break;
 					case OBJECT_STATE_INIT:
 						if (initializingMonrs-- > 0) {
 							continue;
 						}
 						else {
-							RCLCPP_INFO(get_logger(), "Connected object %u in initializing state after connection", obj.getTransmitterID());
-							this->state->connectedToLiveObject(*this, obj.getTransmitterID());
+							RCLCPP_INFO(get_logger(), "Connected object %u in initializing state after connection", obj->getTransmitterID());
+							this->state->connectedToLiveObject(*this, obj->getTransmitterID());
 						}
 						break;
 					case OBJECT_STATE_DISARMED:
-						RCLCPP_INFO(get_logger(), "Connected to disarmed object ID %u", obj.getTransmitterID());
-						this->state->connectedToObject(*this, obj.getTransmitterID());
+						RCLCPP_INFO(get_logger(), "Connected to disarmed object ID %u", obj->getTransmitterID());
+						this->state->connectedToObject(*this, obj->getTransmitterID());
 						break;
 					default:
-						RCLCPP_INFO(get_logger(), "Connected to object %u in unknown state", obj.getTransmitterID());
-						this->state->connectedToLiveObject(*this, obj.getTransmitterID());
+						RCLCPP_INFO(get_logger(), "Connected to object %u in unknown state", obj->getTransmitterID());
+						this->state->connectedToLiveObject(*this, obj->getTransmitterID());
 					}
 					break;
 				}
 			}
 			catch (std::runtime_error &e) {
 				RCLCPP_ERROR(get_logger(), "Connection startup procedure failed for object %u: %s",
-						   obj.getTransmitterID(), e.what());
-				obj.disconnect();
+						   obj->getTransmitterID(), e.what());
+				obj->disconnect();
 				// TODO: connection failed event?
+				// VJCOM: Stop lifecycle nodes here
 			}
 		}
 	}
 	catch (std::invalid_argument &e) {
 		RCLCPP_ERROR(get_logger(), "Bad connection attempt for object %u: %s",
-				   obj.getTransmitterID(), e.what());
-		obj.disconnect();
+				   obj->getTransmitterID(), e.what());
+		obj->disconnect();
+		// VJCOM: Stop lifecycle nodes here
 		// TODO: connection failed event?
 	}
 };
 
 void ObjectControl::remoteControlObjects(bool on) {
 	for (auto& id : getVehicleIDs()) {
-		objects.at(id).sendRemoteControl(on);
+		objects.at(id)->sendRemoteControl(on);
 	}
 }
 
 void ObjectControl::armObjects() {
 	for (auto& id : getVehicleIDs()) {
-		objects.at(id).sendArm();
+		objects.at(id)->sendArm();
 	}
 }
 
 void ObjectControl::disarmObjects() {
 	for (auto& id : getVehicleIDs()) {
 		try {
-			objects.at(id).sendDisarm();
+			objects.at(id)->sendDisarm();
 		}
 		catch (std::invalid_argument& e) {
 			RCLCPP_ERROR(get_logger(), "Unable to disarm object %u: %s", id, e.what());
@@ -595,44 +616,44 @@ void ObjectControl::disarmObjects() {
 
 void ObjectControl::startObjects() {
 	for (auto& id : getVehicleIDs()) {
-		if (!objects.at(id).isStartingOnTrigger()) {
-			objects.at(id).sendStart();
+		if (!objects.at(id)->isStartingOnTrigger()) {
+			objects.at(id)->sendStart();
 		}
 	}
 }
 
 void ObjectControl::allClearObjects() {
 	for (auto& id : getVehicleIDs()) {
-		objects.at(id).sendAllClear();
+		objects.at(id)->sendAllClear();
 	}
 	this->state->allObjectsAbortDisarmed(*this); // TODO wait for all objects really are disarmed
 }
 
 bool ObjectControl::isAnyObjectIn(
 		const ObjectStateType state) {
-	return std::any_of(objects.cbegin(), objects.cend(), [state](const std::pair<const uint32_t,TestObject>& obj) {
-		return obj.second.getState() == state;
+	return std::any_of(objects.cbegin(), objects.cend(), [state](const std::pair<const uint32_t,std::shared_ptr<TestObject>>& obj) {
+		return obj.second->getState() == state;
 	});
 }
 
 bool ObjectControl::areAllObjectsIn(
 		const ObjectStateType state) {
-	return std::all_of(objects.cbegin(), objects.cend(), [state](const std::pair<const uint32_t,TestObject>& obj) {
-		return obj.second.getState() == state;
+	return std::all_of(objects.cbegin(), objects.cend(), [state](const std::pair<const uint32_t,std::shared_ptr<TestObject>>& obj) {
+		return obj.second->getState() == state;
 	});
 }
 
 bool ObjectControl::isAnyObjectIn(
 		const std::set<ObjectStateType>& states) {
-	return std::any_of(objects.cbegin(), objects.cend(), [states](const std::pair<const uint32_t,TestObject>& obj) {
-		return states.find(obj.second.getState()) != states.end();
+	return std::any_of(objects.cbegin(), objects.cend(), [states](const std::pair<const uint32_t,std::shared_ptr<TestObject>>& obj) {
+		return states.find(obj.second->getState()) != states.end();
 	});
 }
 
 bool ObjectControl::areAllObjectsIn(
 		const std::set<ObjectStateType>& states) {
-	return std::all_of(objects.cbegin(), objects.cend(), [states](const std::pair<const uint32_t,TestObject>& obj) {
-		return states.find(obj.second.getState()) != states.end();
+	return std::all_of(objects.cbegin(), objects.cend(), [states](const std::pair<const uint32_t,std::shared_ptr<TestObject>>& obj) {
+		return states.find(obj.second->getState()) != states.end();
 	});
 }
 

--- a/modules/ObjectControl/src/objectlistener.cpp
+++ b/modules/ObjectControl/src/objectlistener.cpp
@@ -17,10 +17,8 @@ static maestro_interfaces::msg::Monitor createROSMessage(const MonitorMessage& d
 ObjectListener::ObjectListener(
 		ObjectControl* sh,
 		std::shared_ptr<TestObject> ob,
-		//ROSChannels::Monitor::Pub& mc,
 		rclcpp::Logger log)
 	:  obj(ob), handler(sh),
-	// monitorChannel(mc), 
 	 Loggable(log)
 {
 	if (!obj->isConnected()) {

--- a/modules/ObjectControl/src/objectlistener.cpp
+++ b/modules/ObjectControl/src/objectlistener.cpp
@@ -16,10 +16,12 @@ static maestro_interfaces::msg::Monitor createROSMessage(const MonitorMessage& d
 
 ObjectListener::ObjectListener(
 		ObjectControl* sh,
-		TestObject* ob,
-		ROSChannels::Monitor::Pub& mc,
+		std::shared_ptr<TestObject> ob,
+		//ROSChannels::Monitor::Pub& mc,
 		rclcpp::Logger log)
-	:  obj(ob), handler(sh), monitorChannel(mc), Loggable(log)
+	:  obj(ob), handler(sh),
+	// monitorChannel(mc), 
+	 Loggable(log)
 {
 	if (!obj->isConnected()) {
 		throw std::invalid_argument("Attempted to start listener for disconnected object");
@@ -57,8 +59,8 @@ void ObjectListener::listen() {
 				auto objData = obj->getAsObjectData();
 				objData.MonrData = monr.second;
 				JournalRecordMonitorData(&objData);
-
-				monitorChannel.publish(createROSMessage(monr));
+				obj->publishMonr(createROSMessage(monr));
+				
 				// Reset thread cancelling
 				pthread_setcancelstate(oldCancelState, nullptr);
 

--- a/modules/ObjectControl/src/testobject.cpp
+++ b/modules/ObjectControl/src/testobject.cpp
@@ -76,7 +76,6 @@ void TestObject::setTriggerStart(
 void TestObject::setLastReceivedTrajectory(ROSChannels::Trajectory::message_type::SharedPtr trajlet){
 	// Warning: ensure thread safety here if other thread uses
 	// lastReceivedTrajectory.
-	RCLCPP_INFO(get_logger(),"Got it!: ");
 	this->lastReceivedTrajectory = trajlet;
 }
 


### PR DESCRIPTION
Each TestObject now publishes its own monr messages on the channel /maestro/object_n/object_monitor. Each object also receives (chunks of) trajs on the topic /maestro/object_n/trajectory, where n is the ID of the object. 

When ObjectControl creates a TestObject, it also initializes a monrPub and a trajSub for the object, which it provides as arguments to the constructor of the TestObject. The pub and sub are shared pointers and get destroyed whenever the TestObject gets destroyed. 