### PR TITLE
Implement sending of synchronized GroundTruth message

### DIFF
--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -29,7 +29,6 @@ class OSIAdapter : public Module
     void sendOSIData();
     std::vector<char> makeOSIMessage(const std::vector<OsiHandler::GlobalObjectGroundTruth_t>& osiData);
     const OsiHandler::GlobalObjectGroundTruth_t makeOSIData(ROSChannels::Monitor::message_type& monr);
-    void extrapolateMonr(ROSChannels::Monitor::message_type& monr, const TimeUnit& dt);
     
     void onAbortMessage(const ROSChannels::Abort::message_type::SharedPtr) override;
     
@@ -50,8 +49,8 @@ class OSIAdapter : public Module
     std::unordered_map<uint32_t,std::shared_ptr<ROSChannels::Monitor::Sub>> monrSubscribers;
 
     void onConnectedObjectIdsMessage(const ROSChannels::ConnectedObjectIds::message_type::SharedPtr msg);
-    void onMonitorMessage(const ROSChannels::Monitor::message_type::SharedPtr msg, uint32_t id);
+    void onMonitorMessage(const ROSChannels::Monitor::message_type::SharedPtr msg, uint32_t id) override;
 
     inline double linPosPrediction(const double position, const double velocity, const TimeUnit dt);
-    void extrapolateMONR(Monitor::message_type& monr, const TimeUnit dt);
+    void extrapolateMONR(ROSChannels::Monitor::message_type& monr, const TimeUnit dt);
 };

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -80,7 +80,7 @@ OSIAdapter::sendOSIData() {
   boost::system::error_code ignored_error;
   
   // Extrapolate monr data and create a sensorView containing the objects
-  std::for_each(lastMonitors.begin(),lastMonitors.end(),[&](auto pair){ OSIAdapter::extrapolateMonr(pair.second,lastMonitorTimes.at(pair.first));});
+  std::for_each(lastMonitors.begin(),lastMonitors.end(),[&](auto pair){ OSIAdapter::extrapolateMONR(pair.second,lastMonitorTimes.at(pair.first));});
   std::vector<OsiHandler::GlobalObjectGroundTruth_t> sensorView(lastMonitors.size());
   std::transform(lastMonitors.begin(),lastMonitors.end(), sensorView.begin(), [&](auto pair) {return OSIAdapter::makeOSIData(pair.second);});
   
@@ -99,9 +99,6 @@ OSIAdapter::sendOSIData() {
     // Either way, reset the socket and go back to listening
     resetTCPServer(endpoint);
   }
-}
-
-void OSIAdapter::extrapolateMonr(ROSChannels::Monitor::message_type& monr, const TimeUnit& dt){
 }
 
 /**
@@ -156,7 +153,7 @@ OSIAdapter::makeOSIData(ROSChannels::Monitor::message_type& monr) {
 
 double
 OSIAdapter::linPosPrediction(const double position, const double velocity, const TimeUnit dt) {
-  return position + velocity * dt.count();
+  return position + velocity * duration<double>(dt).count();
 }
 
 


### PR DESCRIPTION
Added a new unordered_map, lastMonitorTimes for tracking time between 2 last received MONRs. 
Implemented filling of the OSI message with real MONR data. 
Added logic for extrapolating the MONRs and sending them as a SensorView over the socket.