### PR TITLE
Feature - Sending trajectory data in MONR-message

### DIFF
--- a/launch/maestro_launch.py
+++ b/launch/maestro_launch.py
@@ -56,12 +56,12 @@ def generate_launch_description():
             executable='journal_control',
             name='journal_control'
         ),
-        Node(
-            package='rviz2',
-            namespace='maestro',
-            executable='rviz2',
-            name='rviz2'
-        ),
+        # Node(
+        #     package='rviz2',
+        #     namespace='maestro',
+        #     executable='rviz2',
+        #     name='rviz2'
+        # ),
         Node(
             package='maestro',
             namespace='maestro',

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -64,7 +64,8 @@ class OSIAdapter : public Module
     void loadObjectFiles();
     void saveTrajectories();
     void saveTrajPoints();
-    void findNearestTrajectory(const uint16_t id, const double x, const double y);
+    std::vector<double> getDistances(const uint16_t id, const double xCar, const double yCar);
+    void findNearestTrajectory(const uint16_t id, const double xCar, const double yCar);
 
     // Variables
     std::vector<std::unique_ptr<ObjectConfig>> objectConfigurations;

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -66,9 +66,11 @@ class OSIAdapter : public Module
     void saveTrajPoints();
     std::vector<double> getDistances(const uint16_t id, const double xCar, const double yCar);
     int findNearestTrajectory(const uint16_t id, const double xCar, const double yCar);
+    void calculateDistancesInTrajectory();
 
     // Variables
     std::vector<std::unique_ptr<ObjectConfig>> objectConfigurations;
     std::vector<std::unique_ptr<const Trajectory>> trajectories;
     std::vector<std::vector<std::pair<double, double>>> trajPoints;
+    std::vector<std::vector<double>> trajPointsDistances;
 };

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -61,8 +61,6 @@ class OSIAdapter : public Module
     void onMonitorMessage(const ROSChannels::Monitor::message_type::SharedPtr msg, uint32_t id) override;
     void onConnectedObjectIdsMessage(const ROSChannels::ConnectedObjectIds::message_type::SharedPtr msg);
 
-
-    // Trajectory
     void loadObjectFiles();
     void saveTrajectories();
     void saveTrajPoints();
@@ -71,7 +69,6 @@ class OSIAdapter : public Module
     void calculateDistancesInTrajectory();
     std::vector<std::pair<double,double>> extractTrajectoryChunk(const uint16_t id, const double xCar, const double yCar);
 
-    // Variables
     std::vector<std::unique_ptr<ObjectConfig>> objectConfigurations;
     std::map<uint16_t, std::unique_ptr<const Trajectory>> trajectories;
     std::map<uint16_t, std::vector<std::pair<double, double>>> trajPoints;

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -63,8 +63,11 @@ class OSIAdapter : public Module
     // Trajectory
     void loadObjectFiles();
     void saveTrajectories();
+    void saveTrajPoints();
+    void findNearestTrajectory(const uint16_t id, const double x, const double y);
 
     // Variables
     std::vector<std::unique_ptr<ObjectConfig>> objectConfigurations;
     std::vector<std::unique_ptr<const Trajectory>> trajectories;
+    std::vector<std::vector<std::pair<double, double>>> trajPoints;
 };

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <boost/asio.hpp>
+#include <chrono>
 
 #include "module.hpp"
 #include "roschannel.hpp"
 #include "osi_handler.hpp"
 #include "unordered_map"
-#include <chrono>
+#include "objectconfig.hpp"
+
+
 
 class OSIAdapter : public Module
 {
@@ -56,4 +59,10 @@ class OSIAdapter : public Module
     void onMonitorMessage(const ROSChannels::Monitor::message_type::SharedPtr msg, uint32_t id) override;
     void onConnectedObjectIdsMessage(const ROSChannels::ConnectedObjectIds::message_type::SharedPtr msg);
 
+
+    // Trajectory
+    void loadObjectFiles();
+
+    // Variables
+    std::vector<std::unique_ptr<ObjectConfig>> objectConfigurations;
 };

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -30,8 +30,6 @@ class OSIAdapter : public Module
     std::vector<char> makeOSIMessage(const std::vector<OsiHandler::GlobalObjectGroundTruth_t>& osiData);
     const OsiHandler::GlobalObjectGroundTruth_t makeOSIData(ROSChannels::Monitor::message_type& monr);
     
-    void onAbortMessage(const ROSChannels::Abort::message_type::SharedPtr) override;
-    
     ROSChannels::ConnectedObjectIds::Sub connectedObjectIdsSub;	//!< Publisher to report connected objects
     rclcpp::TimerBase::SharedPtr timer;
 
@@ -48,9 +46,13 @@ class OSIAdapter : public Module
     std::unordered_map<uint32_t,TimeUnit> lastMonitorTimes;
     std::unordered_map<uint32_t,std::shared_ptr<ROSChannels::Monitor::Sub>> monrSubscribers;
 
+    inline double linPosPrediction(const double position, const double velocity, const TimeUnit dt);
+    void extrapolateMONR(ROSChannels::Monitor::message_type& monr, const TimeUnit dt);
+
+    void onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) override;
+    void onAbortMessage(const ROSChannels::Abort::message_type::SharedPtr) override;
     void onConnectedObjectIdsMessage(const ROSChannels::ConnectedObjectIds::message_type::SharedPtr msg);
     void onMonitorMessage(const ROSChannels::Monitor::message_type::SharedPtr msg, uint32_t id) override;
 
-    inline double linPosPrediction(const double position, const double velocity, const TimeUnit dt);
-    void extrapolateMONR(ROSChannels::Monitor::message_type& monr, const TimeUnit dt);
+
 };

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -65,7 +65,7 @@ class OSIAdapter : public Module
     void saveTrajectories();
     void saveTrajPoints();
     std::vector<double> getDistances(const uint16_t id, const double xCar, const double yCar);
-    void findNearestTrajectory(const uint16_t id, const double xCar, const double yCar);
+    int findNearestTrajectory(const uint16_t id, const double xCar, const double yCar);
 
     // Variables
     std::vector<std::unique_ptr<ObjectConfig>> objectConfigurations;

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -62,7 +62,9 @@ class OSIAdapter : public Module
 
     // Trajectory
     void loadObjectFiles();
+    void saveTrajectories();
 
     // Variables
     std::vector<std::unique_ptr<ObjectConfig>> objectConfigurations;
+    std::vector<std::unique_ptr<const Trajectory>> trajectories;
 };

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -30,7 +30,6 @@ class OSIAdapter : public Module
     std::vector<char> makeOSIMessage(const std::vector<OsiHandler::GlobalObjectGroundTruth_t>& osiData);
     const OsiHandler::GlobalObjectGroundTruth_t makeOSIData(ROSChannels::Monitor::message_type& monr);
     
-    ROSChannels::ConnectedObjectIds::Sub connectedObjectIdsSub;	//!< Publisher to report connected objects
     rclcpp::TimerBase::SharedPtr timer;
 
     boost::asio::ip::tcp::endpoint endpoint;
@@ -49,10 +48,12 @@ class OSIAdapter : public Module
     inline double linPosPrediction(const double position, const double velocity, const TimeUnit dt);
     void extrapolateMONR(ROSChannels::Monitor::message_type& monr, const TimeUnit dt);
 
+    ROSChannels::Init::Sub initSub;
+    ROSChannels::ConnectedObjectIds::Sub connectedObjectIdsSub;	//!< Publisher to report connected objects
+
     void onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) override;
     void onAbortMessage(const ROSChannels::Abort::message_type::SharedPtr) override;
-    void onConnectedObjectIdsMessage(const ROSChannels::ConnectedObjectIds::message_type::SharedPtr msg);
     void onMonitorMessage(const ROSChannels::Monitor::message_type::SharedPtr msg, uint32_t id) override;
-
+    void onConnectedObjectIdsMessage(const ROSChannels::ConnectedObjectIds::message_type::SharedPtr msg);
 
 };

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -22,7 +22,6 @@ class OSIAdapter : public Module
     using timeUnit = std::chrono::milliseconds;
     static inline std::string const DEFAULT_ADDRESS = "127.0.0.1";
     constexpr static uint16_t DEFAULT_PORT = 55555;
-    constexpr static bool DEFAULT_DEBUG_VALUE = false;
     constexpr static uint8_t QUALITY_OF_SERVICE = 10;
     constexpr static std::chrono::duration SEND_INTERVAL = std::chrono::milliseconds(500);
 

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -26,6 +26,8 @@ class OSIAdapter : public Module
     constexpr static uint16_t DEFAULT_PORT = 55555;
     constexpr static uint8_t QUALITY_OF_SERVICE = 10;
     constexpr static std::chrono::duration SEND_INTERVAL = std::chrono::milliseconds(500);
+    constexpr static int NEAR_POINT_DISTANCE = 2;
+    constexpr static int FAR_POINT_DISTANCE = 10;
 
     static inline std::string const moduleName = "osi_adapter";
 
@@ -67,10 +69,11 @@ class OSIAdapter : public Module
     std::vector<double> getDistances(const uint16_t id, const double xCar, const double yCar);
     int findNearestTrajectory(const uint16_t id, const double xCar, const double yCar);
     void calculateDistancesInTrajectory();
+    std::vector<std::pair<double,double>> extractTrajectoryChunk(const uint16_t id, const double xCar, const double yCar);
 
     // Variables
     std::vector<std::unique_ptr<ObjectConfig>> objectConfigurations;
-    std::vector<std::unique_ptr<const Trajectory>> trajectories;
-    std::vector<std::vector<std::pair<double, double>>> trajPoints;
-    std::vector<std::vector<double>> trajPointsDistances;
+    std::map<uint16_t, std::unique_ptr<const Trajectory>> trajectories;
+    std::map<uint16_t, std::vector<std::pair<double, double>>> trajPoints;
+    std::map<uint16_t, std::vector<double>> trajPointsDistances;
 };

--- a/modules/OSIAdapter/inc/osiadapter.hpp
+++ b/modules/OSIAdapter/inc/osiadapter.hpp
@@ -12,8 +12,7 @@ class OSIAdapter : public Module
 {
   public:
     void initialize(const std::string& address = DEFAULT_ADDRESS,
-                  const uint16_t port = DEFAULT_PORT,
-                  const bool debug = DEFAULT_DEBUG_VALUE);
+                  const uint16_t port = DEFAULT_PORT);
     OSIAdapter();
     ~OSIAdapter();
 

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -241,6 +241,18 @@ OSIAdapter::findNearestTrajectory(const uint16_t id, const double xCar, const do
   return minIndex;
 }
 
+/**
+ * @brief Saves all trajectories in a vector
+ * 
+ */
+void
+OSIAdapter::saveTrajectories() {
+
+  for (auto& config : objectConfigurations) {
+    auto traj = config->getTrajectory();
+    trajectories.emplace_back(std::make_unique<Trajectory>(traj));
+  }
+}
 
 /**
  * @brief Saves the x- and y-coordinates of all trajectories
@@ -287,14 +299,7 @@ OSIAdapter::loadObjectFiles() {
 }
 
 
-void
-OSIAdapter::saveTrajectories() {
 
-  for (auto& config : objectConfigurations) {
-    auto traj = config->getTrajectory();
-    trajectories.emplace_back(std::make_unique<Trajectory>(traj));
-  }
-}
 
 
 void

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -170,6 +170,30 @@ OSIAdapter::extrapolateMONR(ROSChannels::Monitor::message_type& monr,  const Tim
 
 
 void
+OSIAdapter::findNearestTrajectory(const uint16_t id, const double x, const double y) {
+
+
+}
+
+void
+OSIAdapter::saveTrajPoints() {
+
+  for (auto& traj : trajectories) {
+    auto id = traj->id;
+    
+    std::vector<std::pair<double,double>> trajPointsForId;
+    for (auto& points : traj->points) {
+      auto x = points.getXCoord();
+      auto y = points.getYCoord();
+
+      trajPointsForId.emplace_back(std::make_pair(x,y));
+    }
+    trajPoints.emplace_back(trajPointsForId);
+  }
+}
+
+
+void
 OSIAdapter::loadObjectFiles() {
   char path[MAX_FILE_PATH];
 	std::vector<std::invalid_argument> errors;
@@ -206,7 +230,8 @@ OSIAdapter::onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) 
   
   RCLCPP_INFO(get_logger(), "Loading object configuration...");
   loadObjectFiles();
-  saveTrajectories();
+  saveTrajectories(); 
+  saveTrajPoints();
 }
 
 

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -192,12 +192,21 @@ OSIAdapter::loadObjectFiles() {
 
 
 void
+OSIAdapter::saveTrajectories() {
+
+  for (auto& config : objectConfigurations) {
+    auto traj = config->getTrajectory();
+    trajectories.emplace_back(std::make_unique<Trajectory>(traj));
+  }
+}
+
+
+void
 OSIAdapter::onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) {
   
   RCLCPP_INFO(get_logger(), "Loading object configuration...");
   loadObjectFiles();
-  Trajectory traj = objectConfigurations[0]->getTrajectory();
-  
+  saveTrajectories();
 }
 
 

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -173,7 +173,7 @@ OSIAdapter::extrapolateMONR(ROSChannels::Monitor::message_type& monr,  const Tim
 std::vector<double>
 OSIAdapter::getDistances(const uint16_t id, const double xCar, const double yCar) {
 
-  std::vector<std::pair<double,double>> trajectoryPoints = trajPoints[0];
+  std::vector<std::pair<double,double>> trajectoryPoints = trajPoints[id];
   std::vector<double> distances;
 
   for (auto points : trajectoryPoints) {
@@ -186,11 +186,13 @@ OSIAdapter::getDistances(const uint16_t id, const double xCar, const double yCar
     auto distance = sqrt(pow(xDiff, 2) + pow(yDiff, 2));
     distances.emplace_back(distance);
   }
+
+  return distances;
 }
 
 void
 OSIAdapter::findNearestTrajectory(const uint16_t id, const double xCar, const double yCar) {
-  
+
 }
 
 void

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -176,9 +176,9 @@ OSIAdapter::extrapolateMONR(const uint32_t id,  const double deltaT) {
   auto velocityY = monrMessage.velocity.twist.linear.y;
   auto velocityZ = monrMessage.velocity.twist.linear.z;
 
-  auto newPositionX = calculatePosition(positionX, velocityX, deltaT);
-  auto newPositionY = calculatePosition(positionY, velocityY, deltaT);
-  auto newPositionZ = calculatePosition(positionZ, velocityZ, deltaT);
+  auto newPositionX = linPosPrediction(positionX, velocityX, deltaT);
+  auto newPositionY = linPosPrediction(positionY, velocityY, deltaT);
+  auto newPositionZ = linPosPrediction(positionZ, velocityZ, deltaT);
 
   monrMessage.pose.pose.position.x = newPositionX;
   monrMessage.pose.pose.position.y = newPositionY;

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -159,32 +159,7 @@ OSIAdapter::makeOSIData(ROSChannels::Monitor::message_type& monr) {
   osiData.vel_m_s.z = monr.velocity.twist.linear.z;
 
   auto trajChunk = extractTrajectoryChunk(id, xPosition, yPosition);
-  // for (auto pair : trajChunk) {
-  //   // double x = pair.first;
-  //   // double y = pair.second;
-  //   // osiData.trajectory.trajectory.emplace_back(x, y);
-  //   RCLCPP_INFO(get_logger(), "(X, Y) = (%lf, %lf)", pair.first, pair.second);
-  // }
-  // RCLCPP_INFO(get_logger(), "");
-
   osiData.trajectory.trajectory = trajChunk;
-
-  // osiData.trajectory.trajectory.emplace_back(1,1);
-  // osiData.trajectory.trajectory.emplace_back(1,-2);
-  // osiData.trajectory.trajectory.emplace_back(1.23,3);
-  // osiData.trajectory.trajectory.emplace_back(-1,4);
-  // osiData.trajectory.trajectory.emplace_back(-1,4);
-  // osiData.trajectory.trajectory.emplace_back(-1,4);
-  // osiData.trajectory.trajectory.emplace_back(-1,4);
-  // osiData.trajectory.trajectory.emplace_back(-1,4);
-  // osiData.trajectory.trajectory.emplace_back(-1,4);
-  // osiData.trajectory.trajectory.emplace_back(-1,4);
-  // osiData.trajectory.trajectory.emplace_back(-1,4);
-
-
-  // RCLCPP_INFO(get_logger(), "IDDDDDDDDDDDDD: %d", id);
-  // RCLCPP_INFO(get_logger(), "TRAJ SIZEEEE: %d", trajChunk.size());
-
 
   return osiData;
 }

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -108,11 +108,11 @@ OSIAdapter::sendOSIData() {
 }
 
 /**
- * @brief Encodes SvGt message and returns vector to use for sending message in socket. This is currently
- * used for making a test message. In the future timestamp and projStr should come from MONR-message?
+ * @brief Receives a vector of OSI-data, encodes it and copies it into a char-vector to be able
+ * to send over TCP.
  * 
  * @param osiData OSI-data
- * @return std::vector<char> Vector from SvGt encoding
+ * @return std::vector<char> Vector to send over TCP
  */
 std::vector<char>
 OSIAdapter::makeOSIMessage(const std::vector<OsiHandler::GlobalObjectGroundTruth_t>& osiData) {
@@ -129,8 +129,7 @@ OSIAdapter::makeOSIMessage(const std::vector<OsiHandler::GlobalObjectGroundTruth
 }
 
 /**
- * @brief This method creates test OSI-data for testing the module. Should be removed later,
- * since this data should come from MONR-messages.
+ * @brief Make OSI-data from MONR-messages.
  * 
  * @return const OsiHandler::GlobalObjectGroundTruth_t OSI-data 
  */
@@ -164,6 +163,14 @@ OSIAdapter::makeOSIData(ROSChannels::Monitor::message_type& monr) {
   return osiData;
 }
 
+/**
+ * @brief Linear extrapolition in order to predict the new position after a time step.
+ * 
+ * @param position x-, y-, or z-position of object
+ * @param velocity x-, y-, or z-velocity of object
+ * @param dt Time step
+ * @return double New x-, y-, or z-position of object
+ */
 double
 OSIAdapter::linPosPrediction(const double position, const double velocity, const TimeUnit dt) {
   return position + velocity * duration<double>(dt).count();
@@ -207,7 +214,7 @@ OSIAdapter::calculateDistancesInTrajectory() {
 }
 
 /**
- * @brief Finds the distances from the car position (x,y) to all points in the trajectory
+ * @brief Finds the distances from the car position (x,y) to all points in the trajectory.
  * 
  * @param id Object ID
  * @param xCar x-position of car
@@ -235,7 +242,7 @@ OSIAdapter::getDistances(const uint16_t id, const double xCar, const double yCar
 }
 
 /**
- * @brief Finds the index of the trajectory that is the most close a point
+ * @brief Finds the index of the trajectory that is the most close a point.
  * 
  * @param id Object ID
  * @param xCar x-position of car
@@ -250,6 +257,15 @@ OSIAdapter::findNearestTrajectory(const uint16_t id, const double xCar, const do
   return minIndex;
 }
 
+/**
+ * @brief Extracts three points of the trajectory and returns them in a vector. Point 1: The closest point on the
+ * trajectory from the object. Point 2: Point that is in a near distance. Point 3: A point that is in the far distance.
+ * 
+ * @param id ID of object
+ * @param xCar x-coordinate of object
+ * @param yCar y-coordinate of object
+ * @return std::vector<std::pair<double,double>> Vector with the three points
+ */
 std::vector<std::pair<double,double>>
 OSIAdapter::extractTrajectoryChunk(const uint16_t id, const double xCar, const double yCar) {
 
@@ -271,7 +287,6 @@ OSIAdapter::extractTrajectoryChunk(const uint16_t id, const double xCar, const d
     if (trajLength >= FAR_POINT_DISTANCE) {farPointIndex = i; break;}
 
   }
-
   
   auto nearPoint = std::make_pair(points[nearPointIndex].first, points[nearPointIndex].second);
   auto farPoint = std::make_pair(points[farPointIndex].first, points[farPointIndex].second);
@@ -282,7 +297,7 @@ OSIAdapter::extractTrajectoryChunk(const uint16_t id, const double xCar, const d
 }
 
 /**
- * @brief Saves all trajectories in a vector
+ * @brief Saves all trajectories in a map.
  * 
  */
 void
@@ -296,7 +311,7 @@ OSIAdapter::saveTrajectories() {
 }
 
 /**
- * @brief Saves the x- and y-coordinates of all trajectories
+ * @brief Saves the x- and y-coordinates of all trajectories in a map.
  * 
  */
 void
@@ -316,7 +331,7 @@ OSIAdapter::saveTrajPoints() {
 }
 
 /**
- * @brief Loads all object files in order to get the trajectories
+ * @brief Loads all object files in order to get the trajectories and saves the configuration files.
  * 
  */
 void

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -162,7 +162,7 @@ OSIAdapter::makeOSIData(ROSChannels::Monitor::message_type& monr) {
   osiData.orientation_rad.yaw = 0;
 
   auto trajChunk = extractTrajectoryChunk(id, xPosition, yPosition);
-  osiData.trajectory.trajectory = trajChunk;
+  osiData.trajectory.points = trajChunk;
 
   return osiData;
 }

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -241,6 +241,11 @@ OSIAdapter::findNearestTrajectory(const uint16_t id, const double xCar, const do
   return minIndex;
 }
 
+
+/**
+ * @brief Saves the x- and y-coordinates of all trajectories
+ * 
+ */
 void
 OSIAdapter::saveTrajPoints() {
 
@@ -256,6 +261,10 @@ OSIAdapter::saveTrajPoints() {
 }
 
 
+/**
+ * @brief Loads all object files in order to get the trajectories
+ * 
+ */
 void
 OSIAdapter::loadObjectFiles() {
   char path[MAX_FILE_PATH];
@@ -296,7 +305,6 @@ OSIAdapter::onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) 
   saveTrajectories(); 
   saveTrajPoints();
   calculateDistancesInTrajectory();
-  // // findNearestTrajectory(0, 0, 0);
 }
 
 

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -157,6 +157,10 @@ OSIAdapter::makeOSIData(ROSChannels::Monitor::message_type& monr) {
   osiData.vel_m_s.y = monr.velocity.twist.linear.y;
   osiData.vel_m_s.z = monr.velocity.twist.linear.z;
 
+  osiData.orientation_rad.pitch = 0;
+  osiData.orientation_rad.roll = 0;
+  osiData.orientation_rad.yaw = 0;
+
   auto trajChunk = extractTrajectoryChunk(id, xPosition, yPosition);
   osiData.trajectory.trajectory = trajChunk;
 

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -13,7 +13,8 @@ using std::placeholders::_1;
 
 OSIAdapter::OSIAdapter() :
   Module(OSIAdapter::moduleName),
-  connectedObjectIdsSub(*this,std::bind(&OSIAdapter::onConnectedObjectIdsMessage, this, _1))
+  initSub(*this, std::bind(&OSIAdapter::onInitMessage, this, _1)),
+  connectedObjectIdsSub(*this, std::bind(&OSIAdapter::onConnectedObjectIdsMessage, this, _1))
   {
     initialize();
     timer = this->create_wall_timer(SEND_INTERVAL, std::bind(&OSIAdapter::sendOSIData, this));
@@ -167,8 +168,8 @@ OSIAdapter::extrapolateMONR(Monitor::message_type& monr,  const TimeUnit dt) {
 
 
 void
-OSIAdapter::onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) {
-  
+OSIAdapter::onInitMessage(const Init::message_type::SharedPtr msg) {
+  RCLCPP_INFO(get_logger(), "CONNECTED!!!!!!!!!!!!!!!!");
 }
 
 

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -169,7 +169,14 @@ OSIAdapter::extrapolateMONR(ROSChannels::Monitor::message_type& monr,  const Tim
   monr.pose.pose.position.z = linPosPrediction(monr.pose.pose.position.z, monr.velocity.twist.linear.z, dt);
 }
 
-
+/**
+ * @brief Finds the distances from the car position (x,y) to all points in the trajectory
+ * 
+ * @param id Object ID
+ * @param xCar x-position of car
+ * @param yCar y-position of car
+ * @return std::vector<double> Vector of distances from (xCar, yCar) to all points in the trajectory
+ */
 std::vector<double>
 OSIAdapter::getDistances(const uint16_t id, const double xCar, const double yCar) {
 
@@ -190,9 +197,20 @@ OSIAdapter::getDistances(const uint16_t id, const double xCar, const double yCar
   return distances;
 }
 
-void
+/**
+ * @brief Finds the index of the trajectory that is the most close a point
+ * 
+ * @param id Object ID
+ * @param xCar x-position of car
+ * @param yCar y-position of car
+ * @return int Index of the trajectory point most close to (xCar, yCar)
+ */
+int
 OSIAdapter::findNearestTrajectory(const uint16_t id, const double xCar, const double yCar) {
 
+  auto distances = getDistances(id, xCar, yCar);
+  int minIndex = std::distance(distances.begin(), std::min_element(distances.begin(), distances.end()));
+  return minIndex;
 }
 
 void

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -170,6 +170,34 @@ OSIAdapter::extrapolateMONR(ROSChannels::Monitor::message_type& monr,  const Tim
 }
 
 /**
+ * @brief Calculates the distances between following points in all trajectories. The function
+ * puts all distances in a std::vector<std::vector<double>> trajPointsDistances. For instance
+ * trajPointsDistances[0][0] would give the distance for the first trajectory between the two points
+ * at index 0 and index 1.
+ * 
+ */
+void
+OSIAdapter::calculateDistancesInTrajectory() {
+  
+  for (auto& traj : trajectories) {
+    std::vector<double> distances;
+    auto points = traj->points;
+    
+    for (int i = 0; i < points.size() - 1; ++i) {
+      auto currentX = points[i].getXCoord();
+      auto currentY = points[i].getYCoord();
+
+      auto nextX = points[i+1].getXCoord();
+      auto nextY = points[i+1].getYCoord();
+
+      auto distance = sqrt(pow(currentX - nextX, 2) + pow(currentY - nextY, 2));
+      distances.emplace_back(distance);
+    }
+    trajPointsDistances.emplace_back(distances);
+  }
+}
+
+/**
  * @brief Finds the distances from the car position (x,y) to all points in the trajectory
  * 
  * @param id Object ID
@@ -267,7 +295,8 @@ OSIAdapter::onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) 
   loadObjectFiles();
   saveTrajectories(); 
   saveTrajPoints();
-  findNearestTrajectory(0, 0, 0);
+  calculateDistancesInTrajectory();
+  // // findNearestTrajectory(0, 0, 0);
 }
 
 

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -166,6 +166,13 @@ OSIAdapter::extrapolateMONR(Monitor::message_type& monr,  const TimeUnit dt) {
 }
 
 
+void
+OSIAdapter::onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) {
+  
+}
+
+
+
 void OSIAdapter::onConnectedObjectIdsMessage(const ConnectedObjectIds::message_type::SharedPtr msg) {
   for (uint32_t id : msg->ids) {
     if (monrSubscribers.find(id) == monrSubscribers.end()){

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -2,6 +2,7 @@
 #include <boost/asio.hpp>
 #include <algorithm>
 #include <filesystem>
+#include <cmath>
 
 #include "osi_handler.hpp"
 #include "osiadapter.hpp"
@@ -169,23 +170,37 @@ OSIAdapter::extrapolateMONR(ROSChannels::Monitor::message_type& monr,  const Tim
 }
 
 
+std::vector<double>
+OSIAdapter::getDistances(const uint16_t id, const double xCar, const double yCar) {
+
+  std::vector<std::pair<double,double>> trajectoryPoints = trajPoints[0];
+  std::vector<double> distances;
+
+  for (auto points : trajectoryPoints) {
+    auto xPoints = points.first;
+    auto yPoints = points.second;
+
+    auto xDiff = xCar - xPoints;
+    auto yDiff = yCar - yPoints;
+
+    auto distance = sqrt(pow(xDiff, 2) + pow(yDiff, 2));
+    distances.emplace_back(distance);
+  }
+}
+
 void
-OSIAdapter::findNearestTrajectory(const uint16_t id, const double x, const double y) {
-
-
+OSIAdapter::findNearestTrajectory(const uint16_t id, const double xCar, const double yCar) {
+  
 }
 
 void
 OSIAdapter::saveTrajPoints() {
 
   for (auto& traj : trajectories) {
-    auto id = traj->id;
-    
     std::vector<std::pair<double,double>> trajPointsForId;
     for (auto& points : traj->points) {
       auto x = points.getXCoord();
       auto y = points.getYCoord();
-
       trajPointsForId.emplace_back(std::make_pair(x,y));
     }
     trajPoints.emplace_back(trajPointsForId);
@@ -232,6 +247,7 @@ OSIAdapter::onInitMessage(const ROSChannels::Init::message_type::SharedPtr msg) 
   loadObjectFiles();
   saveTrajectories(); 
   saveTrajPoints();
+  findNearestTrajectory(0, 0, 0);
 }
 
 

--- a/modules/OSIAdapter/src/osiadapter.cpp
+++ b/modules/OSIAdapter/src/osiadapter.cpp
@@ -62,7 +62,7 @@ void OSIAdapter::resetTCPServer(ip::tcp::endpoint endpoint) {
  * @param debug Debug or not. Default: false
  */
 void
-OSIAdapter::initialize(const std::string& address, const uint16_t port, bool debug) {
+OSIAdapter::initialize(const std::string& address, const uint16_t port) {
   RCLCPP_INFO(get_logger(), "%s task running with PID %d", get_name(), getpid());
   endpoint = ip::tcp::endpoint(ip::make_address_v4(address), port);
   io_service = std::make_shared<boost::asio::io_service>();


### PR DESCRIPTION
Changes for this pull request:

- Loading configurations file when initialising.
- Saving trajectory points.
- Calculating three points from the trajectories: 
1. A point on the trajectory nearest to the object.
2. A point in the near distance.
3. A point in the far distance. These points can then be used for the driver model.
- Sending the data as an OSI-message.
- Fixed and added some documentation.