### PR TITLE
encapsulate Trajectory in maestro namespace

### DIFF
--- a/common/objectconfig.hpp
+++ b/common/objectconfig.hpp
@@ -33,8 +33,8 @@ public:
 	double getMaximumSpeed() const { return maximumSpeed; }
 	GeographicPositionType getOrigin() const { return origin; }
 	std::string getProjString() const;
-	Trajectory getTrajectory() const { return trajectory; }
-	void setTrajectory(const Trajectory& newTraj) { trajectory = newTraj; } // TODO danger danger - don't do this
+	maestro::Trajectory getTrajectory() const { return trajectory; }
+	void setTrajectory(const maestro::Trajectory& newTraj) { trajectory = newTraj; } // TODO danger danger - don't do this
 	uint32_t getTransmitterID() const { return transmitterID; }
 	double getTurningDiameter() const { return turningDiameter; }
 	std::string getObjectFileName() const { return objectFile.filename().string(); }
@@ -55,7 +55,7 @@ private:
 	double maximumSpeed = 0;
 	bool hasMaximumSpeed = false;
 	GeographicPositionType origin;
-	Trajectory trajectory;
+	maestro::Trajectory trajectory;
 	uint32_t transmitterID = 0;
 	bool turningDiameterKnown = false;
 	double turningDiameter = 0;

--- a/common/tests/test_relativetrajectory.cpp
+++ b/common/tests/test_relativetrajectory.cpp
@@ -8,7 +8,7 @@
 #define VEL_TOL_M_S 0.001
 #define ACC_TOL_M_S2 0.001
 #define HDG_TOL_DEG 0.1
-
+using namespace maestro;
 using traj_pt = Trajectory::TrajectoryPoint;
 static void time_test();
 static void position_test();

--- a/common/trajectory.cpp
+++ b/common/trajectory.cpp
@@ -7,6 +7,7 @@
 #include "logging.h"
 #include "trajectory.hpp"
 
+namespace maestro{
 const std::regex Trajectory::fileHeaderPattern("TRAJECTORY;(" + RegexPatterns::intPattern + ");("
 											   + RegexPatterns::namePattern + ");" + RegexPatterns::versionPattern + ";("
 											   + RegexPatterns::intPattern + ");");
@@ -608,3 +609,4 @@ bool Trajectory::areTimestampsIncreasing() const {
 		return p1.getTime() < p2.getTime();
 	});
 }
+} // namespace maestro

--- a/common/trajectory.hpp
+++ b/common/trajectory.hpp
@@ -12,7 +12,7 @@
 #include <chrono>
 
 #include "util.h"
-
+namespace maestro {
 class Trajectory {
 public:
 	class TrajectoryPoint {
@@ -160,6 +160,6 @@ private:
 
 	bool areTimestampsIncreasing() const;
 };
-
+} // namespace maestro
 
 #endif

--- a/modules/ObjectControl/inc/testobject.hpp
+++ b/modules/ObjectControl/inc/testobject.hpp
@@ -53,7 +53,7 @@ public:
 
 	friend Channel& operator<<(Channel&,const HeabMessageDataType&);
 	friend Channel& operator<<(Channel&,const ObjectSettingsType&);
-	friend Channel& operator<<(Channel&,const Trajectory&);
+	friend Channel& operator<<(Channel&,const maestro::Trajectory&);
 	friend Channel& operator<<(Channel&,const ObjectCommandType&);
 	friend Channel& operator<<(Channel&,const StartMessageType&);
 	friend Channel& operator<<(Channel&,const std::vector<char>&);
@@ -104,14 +104,14 @@ public:
 
 	uint32_t getTransmitterID() const { return conf.getTransmitterID(); }
 	std::string getTrajectoryFileName() const { return conf.getTrajectoryFileName(); }
-	Trajectory getTrajectory() const { return conf.getTrajectory(); }
+	maestro::Trajectory getTrajectory() const { return conf.getTrajectory(); }
 	GeographicPositionType getOrigin() const { return conf.getOrigin(); }
 	ObjectStateType getState(const bool awaitUpdate);
 	ObjectStateType getState(const bool awaitUpdate, const std::chrono::milliseconds timeout);
 	ObjectStateType getState() const { return isConnected() ? state : OBJECT_STATE_UNKNOWN; }
 	ObjectMonitorType getLastMonitorData() const { return lastMonitor; }
 	ObjectConfig getObjectConfig() const { return conf; }
-	void setTrajectory(const Trajectory& newTrajectory) { conf.setTrajectory(newTrajectory); }
+	void setTrajectory(const maestro::Trajectory& newTrajectory) { conf.setTrajectory(newTrajectory); }
 	void setLastReceivedTrajectory(ROSChannels::Trajectory::message_type::SharedPtr);
 	void setCommandAddress(const sockaddr_in& newAddr);
 	void setMonitorAddress(const sockaddr_in& newAddr);

--- a/modules/ObjectControl/src/objectcontrol.cpp
+++ b/modules/ObjectControl/src/objectcontrol.cpp
@@ -19,6 +19,7 @@
 using std::placeholders::_1;
 using namespace ROSChannels;
 using namespace std::chrono_literals;
+using namespace maestro;
 
 ObjectControl::ObjectControl()
 	: Module(ObjectControl::moduleName),

--- a/modules/ObjectControl/src/objectlistener.cpp
+++ b/modules/ObjectControl/src/objectlistener.cpp
@@ -10,7 +10,6 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-
 static ObjectMonitorType transformCoordinate(const ObjectMonitorType& point, const ObjectMonitorType& anchor, const bool debug = false);
 static maestro_interfaces::msg::Monitor createROSMessage(const MonitorMessage& data); // TODO move to somewhere central
 

--- a/modules/ObjectControl/src/testobject.cpp
+++ b/modules/ObjectControl/src/testobject.cpp
@@ -3,6 +3,7 @@
 #include "maestroTime.h"
 #include "datadictionary.h"
 #include "osi_handler.hpp"
+using namespace maestro;
 
 TestObject::TestObject(rclcpp::Logger log,
 		std::shared_ptr<ROSChannels::Trajectory::Sub> trajSub,


### PR DESCRIPTION
To avoid ambiguities when using external libraries, this PR encapsulates the Trajectory class in the maestro:: namespace. 