### PR TITLE
Fixed VirtualObject LanePosition, s-value.

### DIFF
--- a/scripts/openscenario/garage_plan_test_scenario.ipynb
+++ b/scripts/openscenario/garage_plan_test_scenario.ipynb
@@ -82,7 +82,7 @@
     "virtual_speed = 30 / 3.6 # m/s\n",
     "virtual_acceleration = 3.53 # m/s^2\n",
     "virtual_retardation = 10.32 # m/s^2\n",
-    "virtual_O4_point = xosc.LanePosition(0, 0, 1, 0)\n",
+    "virtual_O4_point = xosc.LanePosition(5, 0, 1, 0)\n",
     "virtual_brake_position = xosc.LanePosition(8, 0, 1, 0)\n",
     "virtual_trigger_delay = 3\n",
     "\n",


### PR DESCRIPTION
Setting the LanePostion's s-value to 0 causes Carla (ScenarioRunner) to crash unless there is a roadsegment behind it. The entire car's bounding box needs to be on the mesh. 