### PR TITLE
generate self-signed certs and place them in ~.astazero/ATOS

### DIFF
--- a/launch/launch_utils/generate_cert.py
+++ b/launch/launch_utils/generate_cert.py
@@ -1,0 +1,38 @@
+from OpenSSL import crypto
+def cert_gen(
+    emailAddress="emailAddress",
+    commonName="commonName",
+    countryName="NT",
+    localityName="localityName",
+    stateOrProvinceName="stateOrProvinceName",
+    organizationName="organizationName",
+    organizationUnitName="organizationUnitName",
+    serialNumber=0,
+    validityStartInSeconds=0,
+    validityEndInSeconds=10*365*24*60*60,
+    KEY_FILE = "private.key",
+    CERT_FILE="selfsigned.crt"):
+    #can look at generated file using openssl:
+    #openssl x509 -inform pem -in selfsigned.crt -noout -text
+    # create a key pair
+    k = crypto.PKey()
+    k.generate_key(crypto.TYPE_RSA, 4096)
+    # create a self-signed cert
+    cert = crypto.X509()
+    cert.get_subject().C = countryName
+    cert.get_subject().ST = stateOrProvinceName
+    cert.get_subject().L = localityName
+    cert.get_subject().O = organizationName
+    cert.get_subject().OU = organizationUnitName
+    cert.get_subject().CN = commonName
+    cert.get_subject().emailAddress = emailAddress
+    cert.set_serial_number(serialNumber)
+    cert.gmtime_adj_notBefore(0)
+    cert.gmtime_adj_notAfter(validityEndInSeconds)
+    cert.set_issuer(cert.get_subject())
+    cert.set_pubkey(k)
+    cert.sign(k, 'sha512')
+    with open(CERT_FILE, "wt") as f:
+        f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode("utf-8"))
+    with open(KEY_FILE, "wt") as f:
+        f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode("utf-8"))

--- a/launch/launch_utils/launch_base.py
+++ b/launch/launch_utils/launch_base.py
@@ -1,22 +1,11 @@
 # Don't launch this file directly, rather use the launch files one level up instead
 import os
 from launch_ros.actions import Node
-import subprocess
-from pathlib import Path
 from .validate_files import validate_files
 
 def get_base_nodes():
-    atos_dir = os.path.join(os.path.expanduser('~'), '.astazero', 'ATOS')
-    params = os.path.join(atos_dir, 'conf', 'params.yaml')
 
-    # webgui logging
-    log = open(atos_dir / Path("webgui.log"), 'w')
-    # start webgui server
-    path = Path(__file__).parent.parent.parent.parent.parent.absolute() / Path("etc/simplecontrol/")
-    subprocess.Popen("/usr/bin/npm start --prefix " + str(path),shell=True, stdout=log, stderr=log)
     files = validate_files()
-
-
     return [
         Node(
             package='atos',

--- a/launch/launch_utils/launch_base.py
+++ b/launch/launch_utils/launch_base.py
@@ -1,10 +1,21 @@
 # Don't launch this file directly, rather use the launch files one level up instead
 import os
 from launch_ros.actions import Node
+import subprocess
+from pathlib import Path
+from .validate_files import validate_files
 
 def get_base_nodes():
     atos_dir = os.path.join(os.path.expanduser('~'), '.astazero', 'ATOS')
     params = os.path.join(atos_dir, 'conf', 'params.yaml')
+
+    # webgui logging
+    log = open(atos_dir / Path("webgui.log"), 'w')
+    # start webgui server
+    path = Path(__file__).parent.parent.parent.parent.parent.absolute() / Path("etc/simplecontrol/")
+    subprocess.Popen("/usr/bin/npm start --prefix " + str(path),shell=True, stdout=log, stderr=log)
+    files = validate_files()
+
 
     return [
         Node(
@@ -12,7 +23,7 @@ def get_base_nodes():
             namespace='atos',
             executable='atos_base',
             name='atos_base',
-            parameters=[params]
+            parameters=[files["params"]]
         ),
         Node(
             package='rosbridge_server',
@@ -21,6 +32,8 @@ def get_base_nodes():
             parameters=[
                 {"port": 9090},
                 {"retry_startup_delay": 5.0},
+                {"certfile": str(files["cert"])},
+                {"keyfile": str(files["key"])},
                 {"fragment_timeout": 600},
                 {"max_message_size": 10000000},
                 {"unregister_timeout": 10.0},
@@ -42,7 +55,7 @@ def get_base_nodes():
             namespace='atos',
             executable='object_control',
             name='object_control',
-            parameters=[params]
+            parameters=[files["params"]]
             # ,prefix="xterm -e gdb --args" #Useful for debugging
         ),
         Node(
@@ -56,14 +69,14 @@ def get_base_nodes():
             namespace='atos',
             executable='osi_adapter',
             name='osi_adapter',
-            parameters=[params]
+            parameters=[files["params"]]
         ),
         Node(
             package='atos',
             namespace='atos',
             executable='esmini_adapter',
             name='esmini_adapter',
-            parameters=[params]
+            parameters=[files["params"]]
         ),
         Node(
             package='atos',
@@ -71,7 +84,7 @@ def get_base_nodes():
             executable='mqtt_bridge',
             name='mqtt_bridge',
             # prefix=['gdbserver localhost:3000'], ## To use with VSC debugger
-            parameters=[params],
+            parameters=[files["params"]],
             # arguments=['--ros-args', '--log-level', "debug"] # To get RCL_DEBUG prints
         ),
     ]

--- a/launch/launch_utils/validate_files.py
+++ b/launch/launch_utils/validate_files.py
@@ -12,11 +12,7 @@ def validate_certs(atos_dir):
     cert = certs_dir / Path("selfsigned.crt")
     key = certs_dir / Path("selfsigned.key")
     if not os.path.exists(cert) or not os.path.exists(key):
-        cert_gen(commonName="ATOS", emailAddress="info@astazero.com"
-        ,countryName="SE", localityName="Gothenburg", stateOrProvinceName="Gothenburg"
-        ,organizationName="AstaZero", organizationUnitName="ATOS", serialNumber=0
-        ,validityStartInSeconds=0, validityEndInSeconds=10*365*24*60*60,
-        KEY_FILE = key, CERT_FILE=cert)
+        cert_gen(KEY_FILE = key, CERT_FILE=cert)
     return [cert, key]
 
 def validate_params():

--- a/launch/launch_utils/validate_files.py
+++ b/launch/launch_utils/validate_files.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from .generate_cert import cert_gen
+import os
+
+def validate_certs(atos_dir):
+    # If certs path does not exist, create it
+    certs_dir = atos_dir / Path("certs")
+    if not os.path.exists(certs_dir):
+        os.makedirs(certs_dir)
+
+    # If certs do not exist, create them
+    cert = certs_dir / Path("selfsigned.crt")
+    key = certs_dir / Path("selfsigned.key")
+    if not os.path.exists(cert) or not os.path.exists(key):
+        cert_gen(commonName="ATOS", emailAddress="info@astazero.com"
+        ,countryName="SE", localityName="Gothenburg", stateOrProvinceName="Gothenburg"
+        ,organizationName="AstaZero", organizationUnitName="ATOS", serialNumber=0
+        ,validityStartInSeconds=0, validityEndInSeconds=10*365*24*60*60,
+        KEY_FILE = key, CERT_FILE=cert)
+    return [cert, key]
+
+def validate_params():
+    #todo..
+    pass
+
+
+def validate_files():
+    atos_dir = os.path.join(os.path.expanduser('~'), '.astazero', 'ATOS')
+    params = os.path.join(atos_dir, 'conf', 'params.yaml')
+    cert,key = validate_certs(atos_dir)
+    return {
+        "params": params,
+        "cert": cert,
+        "key": key
+    }


### PR DESCRIPTION
This PR ensures that a self-signed certificate/key pair are generated on startup of atos, and that secure websockets are used by the rosbridge_websocket executable.

The rosbridge_websocket executable in launch.py will use wss:// (secure websockets) if given "keyfile" and "certfile" parameters.

Generating self-signed certificates have the benefits: 
* Running a rosbridge_websocket server with wss:// instead of ws:// allows mobile clients to connect by default (see https://github.com/orgs/foxglove/discussions/650 for more details)
* The cert/key generation also enables usage of https:// and wss:// protocols on the npm server running SimpleControl. 

This PR also starts breaking up launch_base such that validation of ~/.astazero files can occur here instead of in util.c