### PR TITLE
Added atos_interfaces as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "iso22133"]
 	path = iso22133
 	url = git@github.com:RI-SE/iso22133.git
+[submodule "atos_interfaces"]
+	path = atos_interfaces
+	url = git@github.com:RI-SE/atos_interfaces.git

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo ldconfig
 
 ### <a name="atos-interfaces"></a> Installing atos-interfaces
 ```
-git clone https://github.com/RI-SE/atos_interfaces
+git submodule update --init
 ```
 
 
@@ -127,7 +127,7 @@ mkdir -p ~/atos_ws/src
 Create symlinks to atos and atos_interfaces
 ```
 ln -s path/to/ATOS ~/atos_ws/src/atos
-ln -s path/to/atos-interfaces ~/atos_ws/src/atos_interfaces
+ln -s path/to/ATOS/atos_interfaces ~/atos_ws/src/atos_interfaces
 ```
 
 Change directory into the workspace and build


### PR DESCRIPTION
To make the most use of this, you need to `ln -s /path/to/git/ATOS/atos_interfaces atos_interfaces` in your `/path/to/ros_ws/src` dir