### PR TITLE
Feature no pthread cancel

### DIFF
--- a/modules/ObjectControl/inc/testobject.hpp
+++ b/modules/ObjectControl/inc/testobject.hpp
@@ -86,7 +86,9 @@ public:
 	ObjectConnection(rclcpp::Logger log)
 		: cmd(SOCK_STREAM, log),
 		mntr(SOCK_DGRAM, log),
-		Loggable(log) {}
+		Loggable(log) {
+			pipe(interruptionPipeFds);
+		}
 
 	bool isValid() const;
 	bool isConnected() const;
@@ -94,6 +96,9 @@ public:
 				 const std::chrono::milliseconds retryPeriod);
 	void disconnect();
 	ISOMessageID pendingMessageType(bool awaitNext = false);
+	void interruptSocket() {int i = 1; write(interruptionPipeFds[1], &i, sizeof(i));}
+private:
+	int interruptionPipeFds[2];
 };
 
 class TestObject : public Loggable {
@@ -131,6 +136,7 @@ public:
 	void setObjectConfig(ObjectConfig& newObjectConfig);
 	void setTriggerStart(const bool startOnTrigger = true);
 	void setOrigin(const GeographicPositionType&);
+	void interruptSocket() { comms.interruptSocket();}
 	
 	bool isAnchor() const { return conf.isAnchor(); }
 	bool isOsiCompatible() const { return conf.isOSI(); }

--- a/modules/ObjectControl/src/objectlistener.cpp
+++ b/modules/ObjectControl/src/objectlistener.cpp
@@ -39,6 +39,7 @@ ObjectListener::ObjectListener(
 ObjectListener::~ObjectListener() {
 	this->quit = true;
 	RCLCPP_DEBUG(get_logger(), "Awaiting thread exit");
+
 	// Interrupt socket to unblock readMonitorMessage, and allow thread to exit gracefully
 	obj->interruptSocket();
 	listener.join();
@@ -58,14 +59,7 @@ void ObjectListener::listen() {
 					monr.second = transformCoordinate(monr.second, handler->getLastAnchorData(), true);
 				}
 
-				// Disable thread cancelling while accessing shared memory and journals
-				int oldCancelState;
-				pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldCancelState);
-				// Save to memory
-				// TODO disabled in preparation of removing
-				// will be replaced by ROS message
-				// if not disabled, will cause error printouts
-				//DataDictionarySetMonitorData(monr.first, &monr.second, &currentTime);
+				// Publish monitor data to journal
 				auto objData = obj->getAsObjectData();
 				objData.MonrData = monr.second;
 				JournalRecordMonitorData(&objData);
@@ -78,9 +72,6 @@ void ObjectListener::listen() {
 				auto origin = obj->getOrigin();
 				std::array<double,3> llh_0 = {origin.latitude_deg, origin.longitude_deg, origin.altitude_m};
 				obj->publishNavSatFix(createNavSatFixMessage(monr.second.timestamp, llh_0, rosMonr));
-				
-				// Reset thread cancelling
-				pthread_setcancelstate(oldCancelState, nullptr);
 
 				// Check if state has changed
 				if (obj->getState() != prevObjState) {
@@ -126,7 +117,7 @@ void ObjectListener::listen() {
 	} catch (std::invalid_argument& e) {
 		RCLCPP_ERROR(get_logger(), e.what());
 	} catch (std::range_error& e){
-		RCLCPP_DEBUG(get_logger(), e.what()); // Socket was interrupted intentionally
+		RCLCPP_DEBUG(get_logger(), e.what()); // Socket was interrupted intentionally, exit gracefully
 	} catch (std::runtime_error& e) {
 		RCLCPP_ERROR(get_logger(), e.what());
 		obj->disconnect();

--- a/modules/ObjectControl/src/testobject.cpp
+++ b/modules/ObjectControl/src/testobject.cpp
@@ -323,6 +323,8 @@ bool ObjectConnection::isValid() const {
 void ObjectConnection::disconnect() {
 	this->cmd.disconnect();
 	this->mntr.disconnect();
+	close(this->interruptionPipeFds[0]);
+	close(this->interruptionPipeFds[1]);
 }
 
 void TestObject::sendHeartbeat(


### PR DESCRIPTION
Going through old logs, it seems that the following two lines appear together leading up to a crash of object_control:

1649083846.0016840 [object_control-3] failed to take global rclcpp logging mutex
1649083846.0018322 [object_control-3] FATAL: exception not rethrown

FATAL: exception not rethrown can be caused by using pthread_cancel which we utilized. 
My hypothesis is that a thread might have been cancelled while holding the global logging mutex, causing some other thread within the object_control process to be unable to take the global rclcpp logging mutex.

So hopefully by getting rid of pthread_cancel, this bug ceases to be. Would be nice to verify that this does not occur anymore somehow. 