### PR TITLE
Add check so that the job only runs on PRs that are merged.

### DIFF
--- a/.github/workflows/version-tagging.yml
+++ b/.github/workflows/version-tagging.yml
@@ -9,7 +9,8 @@ on:
 
 concurrency: production # Only allow sequential builds
 jobs:
-  Patch:
+  version_tag:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions: write-all
     steps:


### PR DESCRIPTION
This PR fixes an issue where the version tagging action runs on branches that where closed but not merged. 

It also rename the job to version_tag instead of Patch. 