### PR TITLE
EsminiAdapter follows states correctly

### DIFF
--- a/common/roschannels/statechange.hpp
+++ b/common/roschannels/statechange.hpp
@@ -1,0 +1,27 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+
+#include "roschannel.hpp"
+#include "atos_interfaces/msg/state_change.hpp"
+
+namespace ROSChannels {
+    namespace StateChange {
+        const std::string topicName = "state_change";
+        using message_type = atos_interfaces::msg::StateChange;
+        const rclcpp::QoS defaultQoS = rclcpp::QoS(rclcpp::KeepAll());
+
+        class Pub : public BasePub<message_type> {
+        public:
+            Pub(rclcpp::Node& node, const rclcpp::QoS& qos = defaultQoS) : BasePub<message_type>(node, topicName, qos) {}
+        };
+
+        class Sub : public BaseSub<message_type> {
+        public:
+            Sub(rclcpp::Node& node, std::function<void(const message_type::SharedPtr)> callback, const rclcpp::QoS& qos = defaultQoS) : BaseSub<message_type>(node, topicName, callback, qos) {}
+        };
+    }
+}

--- a/modules/EsminiAdapter/inc/esminiadapter.hpp
+++ b/modules/EsminiAdapter/inc/esminiadapter.hpp
@@ -11,6 +11,7 @@
 #include "roschannels/pathchannel.hpp"
 #include "roschannels/monitorchannel.hpp"
 #include "roschannels/gnsspathchannel.hpp"
+#include "roschannels/statechange.hpp"
 #include <unordered_map>
 #include <filesystem>
 #include "esmini/esminiLib.hpp"
@@ -44,6 +45,7 @@ private:
 	ROSChannels::Start::Sub startSub;
 	ROSChannels::Abort::Sub abortSub;
 	ROSChannels::Exit::Sub exitSub;
+	ROSChannels::StateChange::Sub stateChangeSub;
 	std::unordered_map<uint32_t,ROSChannels::Path::Pub> pathPublishers;
 	std::unordered_map<uint32_t,ROSChannels::GNSSPath::Pub> gnssPathPublishers;
 
@@ -59,6 +61,7 @@ private:
 	static void onStaticStartMessage(const ROSChannels::Start::message_type::SharedPtr);
 	static void onStaticAbortMessage(const ROSChannels::Abort::message_type::SharedPtr);
 	static void onStaticExitMessage(const ROSChannels::Exit::message_type::SharedPtr);
+	static void onStaticStateChangeMessage(const ROSChannels::StateChange::message_type::SharedPtr);
 
 	static void onConnectedObjectIdsMessage(const ROSChannels::ConnectedObjectIds::message_type::SharedPtr msg);
 	static void reportObjectPosition(const ROSChannels::Monitor::message_type::SharedPtr monr, uint32_t id);

--- a/modules/EsminiAdapter/inc/esminiadapter.hpp
+++ b/modules/EsminiAdapter/inc/esminiadapter.hpp
@@ -41,9 +41,6 @@ private:
 	ROSChannels::StartObject::Pub startObjectPub;
 	ROSChannels::V2X::Pub v2xPub;
 	ROSChannels::ConnectedObjectIds::Sub connectedObjectIdsSub;
-	ROSChannels::Init::Sub initSub;
-	ROSChannels::Start::Sub startSub;
-	ROSChannels::Abort::Sub abortSub;
 	ROSChannels::Exit::Sub exitSub;
 	ROSChannels::StateChange::Sub stateChangeSub;
 	std::unordered_map<uint32_t,ROSChannels::Path::Pub> pathPublishers;
@@ -57,9 +54,9 @@ private:
 
 	void onMonitorMessage(const ROSChannels::Monitor::message_type::SharedPtr monr, uint32_t id);
 	// Below is a quickfix, fix properly later
-	static void onStaticInitMessage(const ROSChannels::Init::message_type::SharedPtr);
-	static void onStaticStartMessage(const ROSChannels::Start::message_type::SharedPtr);
-	static void onStaticAbortMessage(const ROSChannels::Abort::message_type::SharedPtr);
+	static void handleInitCommand();
+	static void handleStartCommand();
+	static void handleAbortCommand();
 	static void onStaticExitMessage(const ROSChannels::Exit::message_type::SharedPtr);
 	static void onStaticStateChangeMessage(const ROSChannels::StateChange::message_type::SharedPtr);
 

--- a/modules/EsminiAdapter/src/esminiadapter.cpp
+++ b/modules/EsminiAdapter/src/esminiadapter.cpp
@@ -54,7 +54,8 @@ EsminiAdapter::EsminiAdapter() : Module(moduleName),
 	startSub(*this, &EsminiAdapter::onStaticStartMessage),
 	abortSub(*this, &EsminiAdapter::onStaticAbortMessage),
 	exitSub(*this, &EsminiAdapter::onStaticExitMessage),
-	connectedObjectIdsSub(*this, &EsminiAdapter::onConnectedObjectIdsMessage)
+	connectedObjectIdsSub(*this, &EsminiAdapter::onConnectedObjectIdsMessage),
+	stateChangeSub(*this, &EsminiAdapter::onStaticStateChangeMessage)
  {
 	declare_parameter("open_scenario_file","");
 }
@@ -108,6 +109,7 @@ std::shared_ptr<EsminiAdapter> EsminiAdapter::instance() {
 		me->startSub = ROSChannels::Start::Sub(*me,&EsminiAdapter::onStaticStartMessage);
 		me->abortSub = ROSChannels::Abort::Sub(*me,&EsminiAdapter::onStaticAbortMessage);
 		me->exitSub = ROSChannels::Exit::Sub(*me,&EsminiAdapter::onStaticExitMessage);
+		me->stateChangeSub = ROSChannels::StateChange::Sub(*me,&EsminiAdapter::onStaticStateChangeMessage);
 		// Start V2X publisher
 		me->v2xPub = ROSChannels::V2X::Pub(*me);
 		
@@ -128,6 +130,13 @@ void EsminiAdapter::onConnectedObjectIdsMessage(const ConnectedObjectIds::messag
 }
 
 //! Message queue callbacks
+
+void EsminiAdapter::onStaticStateChangeMessage(const ROSChannels::StateChange::message_type::SharedPtr) {
+	std::cerr << "State changed!\n";
+}
+
+
+
 
 void EsminiAdapter::onStaticAbortMessage(const Abort::message_type::SharedPtr) {
 	SE_Close();

--- a/modules/EsminiAdapter/src/esminiadapter.cpp
+++ b/modules/EsminiAdapter/src/esminiadapter.cpp
@@ -50,11 +50,8 @@ geographic_msgs::msg::GeoPose EsminiAdapter::testOrigin = geographic_msgs::msg::
 EsminiAdapter::EsminiAdapter() : Module(moduleName),
 	startObjectPub(*this),
 	v2xPub(*this),
-	initSub(*this, &EsminiAdapter::onStaticInitMessage),
-	startSub(*this, &EsminiAdapter::onStaticStartMessage),
-	abortSub(*this, &EsminiAdapter::onStaticAbortMessage),
-	exitSub(*this, &EsminiAdapter::onStaticExitMessage),
 	connectedObjectIdsSub(*this, &EsminiAdapter::onConnectedObjectIdsMessage),
+	exitSub(*this, &EsminiAdapter::onStaticExitMessage),
 	stateChangeSub(*this, &EsminiAdapter::onStaticStateChangeMessage)
  {
 	declare_parameter("open_scenario_file","");
@@ -105,9 +102,6 @@ std::shared_ptr<EsminiAdapter> EsminiAdapter::instance() {
 		me = std::shared_ptr<EsminiAdapter>(new EsminiAdapter());
 		// Start listening to connected object ids
 		me->connectedObjectIdsSub = ROSChannels::ConnectedObjectIds::Sub(*me,&EsminiAdapter::onConnectedObjectIdsMessage);
-		me->initSub = ROSChannels::Init::Sub(*me,&EsminiAdapter::onStaticInitMessage);
-		me->startSub = ROSChannels::Start::Sub(*me,&EsminiAdapter::onStaticStartMessage);
-		me->abortSub = ROSChannels::Abort::Sub(*me,&EsminiAdapter::onStaticAbortMessage);
 		me->exitSub = ROSChannels::Exit::Sub(*me,&EsminiAdapter::onStaticExitMessage);
 		me->stateChangeSub = ROSChannels::StateChange::Sub(*me,&EsminiAdapter::onStaticStateChangeMessage);
 		// Start V2X publisher
@@ -129,22 +123,35 @@ void EsminiAdapter::onConnectedObjectIdsMessage(const ConnectedObjectIds::messag
 	}
 }
 
-//! Message queue callbacks
+/**
+ * @brief To ensure that EsminiAdapter follows the states, we execute actions only when going from IDLE to INITIALIZED,
+ * from ARMED to RUNNING and from any state to ABORTING. We do this instead of subscribing to "/init", "/start", etc.,
+ * because we only want to execute the actions once when changing to these states.
+ * 
+ * @param msg StateChange message
+ */
+void EsminiAdapter::onStaticStateChangeMessage(const ROSChannels::StateChange::message_type::SharedPtr msg) {
+	int prevState = msg->prev_state;
+	int currentState = msg->current_state;
 
-void EsminiAdapter::onStaticStateChangeMessage(const ROSChannels::StateChange::message_type::SharedPtr) {
-	std::cerr << "State changed!\n";
+	if (prevState == OBCState_t::OBC_STATE_IDLE && currentState == OBC_STATE_INITIALIZED) {
+		me->handleInitCommand();
+	}
+	else if (prevState == OBCState_t::OBC_STATE_ARMED && currentState == OBCState_t::OBC_STATE_RUNNING) {
+		me->handleStartCommand();
+	}
+	else if (currentState == OBCState_t::OBC_STATE_ABORTING) {
+		me->handleAbortCommand();
+	}
 }
 
 
-
-
-void EsminiAdapter::onStaticAbortMessage(const Abort::message_type::SharedPtr) {
+void EsminiAdapter::handleAbortCommand() {
 	SE_Close();
 	RCLCPP_INFO(me->get_logger(), "Esmini ScenarioEngine stopped due to Abort");
 }
 
-void EsminiAdapter::onStaticInitMessage(
-	const Init::message_type::SharedPtr)
+void EsminiAdapter::handleInitCommand()
 {
 	try {
 		setOpenScenarioFile(getOpenScenarioFileParameter());
@@ -172,17 +179,14 @@ void EsminiAdapter::onStaticInitMessage(
 	});
 }
 
-void EsminiAdapter::onStaticExitMessage(
-	const Exit::message_type::SharedPtr)
+void EsminiAdapter::onStaticExitMessage(const ROSChannels::Exit::message_type::SharedPtr)
 {
 	SE_Close();
 	RCLCPP_DEBUG(me->get_logger(),"Received exit command");
 	rclcpp::shutdown();
 }
 
-// !!TODO!!: Make sure that we are in the correct OBC state before starting ScenarioEngine
-void EsminiAdapter::onStaticStartMessage(
-	const Start::message_type::SharedPtr)
+void EsminiAdapter::handleStartCommand()
 {
 	if (SE_Init(me->oscFilePath.c_str(),0,0,0,0) < 0) {
 		throw std::runtime_error("Failed to initialize esmini with scenario file " + me->oscFilePath.string());

--- a/modules/ObjectControl/inc/objectcontrol.hpp
+++ b/modules/ObjectControl/inc/objectcontrol.hpp
@@ -21,6 +21,7 @@
 #include "roschannels/pathchannel.hpp"
 #include "roschannels/controlsignalchannel.hpp"
 #include "roschannels/objstatechangechannel.hpp"
+#include "roschannels/statechange.hpp"
 #include "atos_interfaces/srv/get_object_ids.hpp"
 #include "atos_interfaces/srv/get_object_trajectory.hpp"
 #include "atos_interfaces/srv/get_object_ip.hpp"
@@ -265,6 +266,7 @@ private:
 	ROSChannels::Abort::Pub scnAbortPub;					//!< Publisher to scenario abort reports
 	ROSChannels::ObjectsConnected::Pub objectsConnectedPub;	//!< Publisher to report that objects have been connected
 	ROSChannels::ConnectedObjectIds::Pub connectedObjectIdsPub;	//!< Publisher to periodically report connected object ids
+	ROSChannels::StateChange::Pub stateChangePub;	//!< Publisher to report state changes
 	rclcpp::Client<atos_interfaces::srv::GetObjectIds>::SharedPtr idClient;	//!< Client to request object ids
 	rclcpp::Client<atos_interfaces::srv::GetTestOrigin>::SharedPtr originClient;	//!< Client to request object status
 	rclcpp::Client<atos_interfaces::srv::GetObjectTrajectory>::SharedPtr trajectoryClient;	//!< Client to request object trajectories

--- a/modules/ObjectControl/src/objectcontrol.cpp
+++ b/modules/ObjectControl/src/objectcontrol.cpp
@@ -46,6 +46,7 @@ ObjectControl::ObjectControl(std::shared_ptr<rclcpp::executors::MultiThreadedExe
 	scnAbortPub(*this),
 	objectsConnectedPub(*this),
 	connectedObjectIdsPub(*this),
+	stateChangePub(*this),
 	exec(exec)
 {
 	int queueSize=0;
@@ -111,37 +112,58 @@ void ObjectControl::handleExecuteActionCommand(
 
 void ObjectControl::onInitMessage(const Init::message_type::SharedPtr){
 	COMMAND cmd = COMM_INIT;
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
 	auto f_try = [&]() { this->state->initializeRequest(*this); };
 	auto f_catch = [&]() { failurePub.publish(msgCtr1<Failure::message_type>(cmd)); };
 	this->tryHandleMessage(f_try,f_catch, Init::topicName, get_logger());
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onConnectMessage(const Connect::message_type::SharedPtr){	
 	COMMAND cmd = COMM_CONNECT;
+	// TO DO: Fix publishing correct data to stateChangeMsg
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
 	auto f_try = [&]() { this->state->connectRequest(*this); };
 	auto f_catch = [&]() { failurePub.publish(msgCtr1<Failure::message_type>(cmd)); };
 	this->tryHandleMessage(f_try,f_catch, Connect::topicName, get_logger());
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onArmMessage(const Arm::message_type::SharedPtr){	
 	COMMAND cmd = COMM_ARM;
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
 	auto f_try = [&]() { this->state->armRequest(*this); };
 	auto f_catch = [&]() { failurePub.publish(msgCtr1<Failure::message_type>(cmd)); };
 	this->tryHandleMessage(f_try,f_catch, Arm::topicName, get_logger());
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onDisarmMessage(const Disarm::message_type::SharedPtr){	
 	COMMAND cmd = COMM_DISARM;
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
 	auto f_try = [&]() { this->state->disarmRequest(*this); };
 	auto f_catch = [&]() { failurePub.publish(msgCtr1<Failure::message_type>(cmd)); };
 	this->tryHandleMessage(f_try,f_catch, Disarm::topicName, get_logger());
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onStartMessage(const Start::message_type::SharedPtr){	
 	COMMAND cmd = COMM_STRT;
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
 	auto f_try = [&]() { this->state->startRequest(*this); };
 	auto f_catch = [&]() { failurePub.publish(msgCtr1<Failure::message_type>(cmd)); };
 	this->tryHandleMessage(f_try,f_catch, Start::topicName, get_logger());
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onStartObjectMessage(const StartObject::message_type::SharedPtr strtObj){
@@ -154,32 +176,48 @@ void ObjectControl::onStartObjectMessage(const StartObject::message_type::Shared
 
 void ObjectControl::onDisconnectMessage(const Disconnect::message_type::SharedPtr){	
 	COMMAND cmd = COMM_DISCONNECT;
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
 	auto f_try = [&]() { this->state->disconnectRequest(*this); };
 	auto f_catch = [&]() { failurePub.publish(msgCtr1<Failure::message_type>(cmd)); };
 	this->tryHandleMessage(f_try,f_catch, Disconnect::topicName, get_logger());
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onStopMessage(const Stop::message_type::SharedPtr){
 	COMMAND cmd = COMM_STOP;
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
 	auto f_try = [&]() { this->state->stopRequest(*this); };
 	auto f_catch = [&]() {
 			failurePub.publish(msgCtr1<Failure::message_type>(cmd));
 			scnAbortPub.publish(Abort::message_type());
 	};
 	this->tryHandleMessage(f_try,f_catch, Stop::topicName, get_logger());	
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onAbortMessage(const Abort::message_type::SharedPtr){
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
   publishScenarioInfoToJournal(); // TODO: This should be moved to a state that occurs right after a test is finished
 	// Any exceptions here should crash the program
 	this->state->abortRequest(*this);
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onAllClearMessage(const AllClear::message_type::SharedPtr){
 	COMMAND cmd = COMM_ABORT_DONE;
+	atos_interfaces::msg::StateChange stateChangeMsg = atos_interfaces::msg::StateChange();
+	stateChangeMsg.prev_state = this->state->asNumber();
 	auto f_try = [&]() { this->state->allClearRequest(*this); };
 	auto f_catch = [&]() { failurePub.publish(msgCtr1<Failure::message_type>(cmd)); };
 	this->tryHandleMessage(f_try,f_catch, AllClear::topicName, get_logger());
+	stateChangeMsg.current_state = this->state->asNumber();
+	stateChangePub.publish(stateChangeMsg);
 }
 
 void ObjectControl::onRemoteControlEnableMessage(const RemoteControlEnable::message_type::SharedPtr){


### PR DESCRIPTION
Instead of subscribing to `/init`, `/start`, etc., this module subscribes to state changes (https://github.com/RI-SE/atos_interfaces/pull/21). When the state changes (e.g. from IDLE to INIT), the scenario is initialized. Previously it was possible to press the init button multiple times, resulting in esmini running multiple times, which should not be possible. The same goes for when pressing start multiple times.

This PR solves this issue, making it possible to only initialise and run the scenario when it's supposed to. Don't forget to use the correct version of `atos_interfaces` when running this.

Some things added:
- `ObjectControl` publishes a message when the state changes
- `EsminiAdapter` subscribes to the state change message
- The subscribers to `/init`, `/start` etc. has been removed and replaced by the state change subscriber instead