### PR TITLE
Error output from esmini to log

### DIFF
--- a/launch/launch_utils/validate_files.py
+++ b/launch/launch_utils/validate_files.py
@@ -45,7 +45,7 @@ def validate_certs(directory_path):
 
 def validate_files():
     atos_dir = os.path.join(os.path.expanduser('~'), '.astazero', 'ATOS')
-    dirs_to_validate = ["conf", "pointclouds"]
+    dirs_to_validate = ["conf", "pointclouds", "logs"]
     for dir_to_validate in dirs_to_validate:
         validate_directory(atos_dir / Path(dir_to_validate))
 

--- a/modules/EsminiAdapter/src/esminiadapter.cpp
+++ b/modules/EsminiAdapter/src/esminiadapter.cpp
@@ -524,11 +524,13 @@ void EsminiAdapter::InitializeEsmini()
 	me->idToIp.clear();
 	me->pathPublishers.clear();
 	me->gnssPathPublishers.clear();
+	auto logFilePath = std::string(getenv("HOME")) + std::string("/.astazero/ATOS/logs/esmini.log");
+	SE_SetLogFilePath(logFilePath.c_str());
 	SE_Close(); // Stop ScenarioEngine in case it is running
 
 	RCLCPP_INFO(me->get_logger(), "Initializing esmini with scenario file %s", me->oscFilePath.c_str());
 	if (SE_Init(me->oscFilePath.c_str(),1,0,0,0) < 0) { // Disable controllers, let DefaultController be used
-		throw std::runtime_error("Failed to initialize esmini with scenario file " + me->oscFilePath.string());
+		throw std::runtime_error("Failed to initialize esmini with scenario file " + me->oscFilePath.string() + ". For more information, see " + logFilePath + ".");
 	}
 	
 	for (int j = 0; j < SE_GetNumberOfObjects(); j++){


### PR DESCRIPTION
Added the error log from esmini to `~/.astazero/ATOS/logs/esmini.log`, making it easier to see what went wrong if there is problems with the scenario.