### PR TITLE
Params and test mode updated

### DIFF
--- a/launch/launch_experimental.py
+++ b/launch/launch_experimental.py
@@ -16,7 +16,8 @@ def get_experimental_nodes():
             package='atos',
             namespace='atos',
             executable='trajectorylet_streamer',
-            name='trajectorylet_streamer'
+            name='trajectorylet_streamer',
+            parameters=[files["params"]]
         ),
         Node(
             package='atos',

--- a/modules/ObjectControl/src/testobject.cpp
+++ b/modules/ObjectControl/src/testobject.cpp
@@ -265,6 +265,8 @@ void TestObject::sendHeartbeat(
 void TestObject::sendSettings() {
 
 	ObjectSettingsType objSettings;
+	objSettings.testMode = TEST_MODE_PREPLANNED;
+
 	objSettings.desiredID.transmitter = conf.getTransmitterID();
 	objSettings.desiredID.controlCentre = ::getTransmitterID();
 	objSettings.desiredID.subTransmitter = 0;


### PR DESCRIPTION
Added the parameters for TrajectoryletStreamer so it can read the parameters from `params.yaml`. Also added test mode for the test object so that the ISO-object gets a value for it. This will need to be changed later when all test modes aren't preplanned.