### PR TITLE
Added handling of GREM messages

### DIFF
--- a/modules/ObjectControl/inc/channel.hpp
+++ b/modules/ObjectControl/inc/channel.hpp
@@ -49,5 +49,5 @@ public:
 
 	friend Channel& operator>>(Channel&,MonitorMessage&);
 	friend Channel& operator>>(Channel&,ObjectPropertiesType&);
-
+	friend Channel& operator>>(Channel&,GeneralResponseMessageType&);
 };

--- a/modules/ObjectControl/inc/testobject.hpp
+++ b/modules/ObjectControl/inc/testobject.hpp
@@ -120,6 +120,12 @@ public:
 		RCLCPP_DEBUG(get_logger(), "Ignoring object properties message");
 		return retval;
 	}
+	virtual GeneralResponseMessageType parseGremMessage() {
+		GeneralResponseMessageType retval;
+		this->comms.cmd >> retval;
+		RCLCPP_DEBUG(get_logger(), "Ignoring general response message");
+		return retval;
+	}
 	virtual void handleISOMessage(bool awaitNext = false);
 
 protected:

--- a/modules/ObjectControl/src/channel.cpp
+++ b/modules/ObjectControl/src/channel.cpp
@@ -146,6 +146,22 @@ Channel& operator>>(Channel& chnl, ObjectPropertiesType& prop) {
 	return chnl;
 }
 
+Channel& operator>>(Channel& chnl, GeneralResponseMessageType& grem) {
+	if (chnl.pendingMessageType() == MESSAGE_ID_GREM) {
+		auto nBytes = decodeGREMMessage(chnl.receiveBuffer.data(), chnl.receiveBuffer.size(), &grem, false);
+		if (nBytes < 0) {
+			throw std::invalid_argument(strerror(errno));
+		}
+		else {
+			nBytes = recv(chnl.socket, chnl.receiveBuffer.data(), static_cast<size_t>(nBytes), 0);
+			if (nBytes <= 0) {
+				throw std::runtime_error("Unable to clear from socket buffer");
+			}
+		}
+	}
+	return chnl;
+}
+
 Channel& operator<<(Channel& chnl, const ControlSignal::message_type::SharedPtr csp) {
 	RemoteControlManoeuvreMessageType rcmm;
 	rcmm.command = MANOEUVRE_NONE;

--- a/modules/ObjectControl/src/testobject.cpp
+++ b/modules/ObjectControl/src/testobject.cpp
@@ -171,6 +171,9 @@ void TestObject::handleISOMessage(bool awaitNext) {
 	case MESSAGE_ID_VENDOR_SPECIFIC_ASTAZERO_OPRO:
 		this->parseObjectPropertyMessage();
 		break;
+	case MESSAGE_ID_GREM:
+		this->parseGremMessage();
+		break;
 	default:
 		RCLCPP_WARN(get_logger(), "Received unknown message type");
 		break;


### PR DESCRIPTION
If test mode is set to online mode, we also receive a GREM message. Handling of this message wasn't implemented which led to strange behaviours when setting test mode to online mode. This PR fixes this.