### PR TITLE
Fix segmentation fault

### DIFF
--- a/modules/TrajectoryletStreamer/inc/trajectoryletstreamer.hpp
+++ b/modules/TrajectoryletStreamer/inc/trajectoryletstreamer.hpp
@@ -42,7 +42,7 @@ class TrajectoryletStreamer : public Module {
 	rclcpp::Client<atos_interfaces::srv::GetObjectTrajectory>::SharedPtr
 		trajectoryClient;  //!< Client to request object trajectories
 
-	std::vector<TrajectoryPublisher> publishers;
+	std::vector<std::shared_ptr<TrajectoryPublisher>> publishers;
 
 	std::map<uint32_t, std::unique_ptr<ATOS::Trajectory>> trajectories;
 

--- a/modules/TrajectoryletStreamer/inc/trajectoryletstreamer.hpp
+++ b/modules/TrajectoryletStreamer/inc/trajectoryletstreamer.hpp
@@ -25,7 +25,6 @@ class TrajectoryletStreamer : public Module {
 	static inline std::string const moduleName = "trajectorylet_streamer";
 	void onInitMessage(const ROSChannels::Init::message_type::SharedPtr);
 	void onObjectsConnectedMessage(const ROSChannels::ObjectsConnected::message_type::SharedPtr);
-	void onStartMessage(const ROSChannels::Start::message_type::SharedPtr);
 	void onAbortMessage(const ROSChannels::Abort::message_type::SharedPtr) override;
 	void onStopMessage(const ROSChannels::Stop::message_type::SharedPtr) override;
 
@@ -34,7 +33,6 @@ class TrajectoryletStreamer : public Module {
 
 	ROSChannels::Init::Sub initSub;
 	ROSChannels::ObjectsConnected::Sub connectedSub;
-	ROSChannels::Start::Sub startSub;
 	ROSChannels::Abort::Sub abortSub;
 	ROSChannels::Stop::Sub stopSub;
 

--- a/modules/TrajectoryletStreamer/inc/trajectorypublisher.hpp
+++ b/modules/TrajectoryletStreamer/inc/trajectorypublisher.hpp
@@ -5,6 +5,7 @@
  */
 #include "objectconfig.hpp"
 #include "roschannels/pathchannel.hpp"
+#include "roschannels/commandchannels.hpp"
 #include <memory>
 #include <thread>
 #include <mutex>
@@ -24,13 +25,13 @@ public:
 		const uint32_t objectId,
 		const std::chrono::milliseconds chunkLength
 			= std::chrono::milliseconds(0));
-	void handleStart();
 
 	void setChunkLength(std::chrono::milliseconds chunkLength) {
 		this->chunkLength = chunkLength;
 	}
 private:
 	ROSChannels::Path::Pub pub;
+	ROSChannels::StartObject::Sub	startObjectSub;
 	std::shared_ptr<rclcpp::TimerBase> timer;
 
 	std::chrono::milliseconds chunkLength = std::chrono::milliseconds(0);
@@ -42,6 +43,7 @@ private:
 	Chunk lastPublishedChunk;
 
 	void publishChunk();
+	void getStartObjectMsg(const atos_interfaces::msg::ObjectTriggerStart::SharedPtr msg);
 	nav_msgs::msg::Path chunkToPath(Chunk chunk, std::chrono::steady_clock::time_point);
 	Chunk extractChunk(std::chrono::steady_clock::duration beginTime, std::chrono::steady_clock::duration endTime);
 

--- a/modules/TrajectoryletStreamer/src/trajectoryletstreamer.cpp
+++ b/modules/TrajectoryletStreamer/src/trajectoryletstreamer.cpp
@@ -15,7 +15,6 @@ TrajectoryletStreamer::TrajectoryletStreamer()
 	: Module(TrajectoryletStreamer::moduleName),
 	  initSub(*this, std::bind(&TrajectoryletStreamer::onInitMessage, this, _1)),
 	  connectedSub(*this, std::bind(&TrajectoryletStreamer::onObjectsConnectedMessage, this, _1)),
-	  startSub(*this, std::bind(&TrajectoryletStreamer::onStartMessage, this, _1)),
 	  stopSub(*this, std::bind(&TrajectoryletStreamer::onStopMessage, this, _1)),
 	  abortSub(*this, std::bind(&TrajectoryletStreamer::onAbortMessage, this, _1)) {
 	declare_parameter("chunk_duration", 0.0);
@@ -37,11 +36,6 @@ void TrajectoryletStreamer::onObjectsConnectedMessage(const ObjectsConnected::me
 	}
 }
 
-void TrajectoryletStreamer::onStartMessage(const std_msgs::msg::Empty::SharedPtr) {
-	for (auto& pub : publishers) {
-		pub->handleStart();
-	}
-}
 
 void TrajectoryletStreamer::loadObjectFiles() {
 	clearScenario();

--- a/modules/TrajectoryletStreamer/src/trajectoryletstreamer.cpp
+++ b/modules/TrajectoryletStreamer/src/trajectoryletstreamer.cpp
@@ -33,13 +33,13 @@ void TrajectoryletStreamer::onObjectsConnectedMessage(const ObjectsConnected::me
 	// TODO setup and first chunk transmission
 	RCLCPP_INFO(get_logger(), "Starting trajectory publishers");
 	for (const auto& [id, traj] : trajectories) {
-		publishers.emplace_back(*this, *traj, id, chunkLength);
+		publishers.emplace_back(std::make_shared<TrajectoryPublisher>(*this, *traj, id, chunkLength));
 	}
 }
 
 void TrajectoryletStreamer::onStartMessage(const std_msgs::msg::Empty::SharedPtr) {
 	for (auto& pub : publishers) {
-		pub.handleStart();
+		pub->handleStart();
 	}
 }
 

--- a/modules/TrajectoryletStreamer/src/trajectorypublisher.cpp
+++ b/modules/TrajectoryletStreamer/src/trajectorypublisher.cpp
@@ -18,6 +18,7 @@ TrajectoryPublisher::TrajectoryPublisher(
 	const std::chrono::milliseconds chunkLength)
 	: traj(std::make_unique<const Trajectory>(_traj)),
 	pub(node, objectId),
+	startObjectSub(node, std::bind(&TrajectoryPublisher::getStartObjectMsg, this, std::placeholders::_1)),
 	lastPublishedChunk(traj->points.end(), traj->points.end()),
 	chunkLength(chunkLength)
 {
@@ -47,10 +48,11 @@ void TrajectoryPublisher::publishChunk()
 	}
 }
 
-
-void TrajectoryPublisher::handleStart() {
+void TrajectoryPublisher::getStartObjectMsg(const atos_interfaces::msg::ObjectTriggerStart::SharedPtr msg) {
 	using std::chrono::steady_clock;
-	startTime.reset(new steady_clock::time_point(steady_clock::now()));
+	if (msg->id == pub.objectId) {
+		startTime.reset(new steady_clock::time_point(steady_clock::now()));
+	}
 }
 
 


### PR DESCRIPTION
This PR fixes the segmentation fault that occured in the module `TrajectoryletStreamer` when more than one object were connected. There was also a timing issue in the publishing of chunks, meaning that the publishing of chunks all started at the same time. This shouldn't be the case though since usually the objects don't start at the same time. This was solved by listening to the topic `/atos/start_object` and the publishing of chunks now start at the correct times.