### PR TITLE
remove progress bar from install script

### DIFF
--- a/gui/controlpanel/CMakeLists.txt
+++ b/gui/controlpanel/CMakeLists.txt
@@ -4,7 +4,7 @@ project(atos_gui)
 add_custom_target(${PROJECT_NAME} ALL)
 add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	COMMAND npm install
+	COMMAND npm install --no-progress
 	COMMAND npx generate-ros-messages #this command does not work in CMAKE_CURRENT_BINARY_DIR for some reason..
 )
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
removes the spammed idealTree status when building atos, the status spam can be seen in the attached image:
![image](https://github.com/RI-SE/ATOS/assets/97448034/9e9c8ab7-4fa0-47d6-8b63-2b5cc0807d79)
