### PR TITLE
Check for if scenario engine should quit

### DIFF
--- a/modules/EsminiAdapter/src/esminiadapter.cpp
+++ b/modules/EsminiAdapter/src/esminiadapter.cpp
@@ -564,6 +564,10 @@ void EsminiAdapter::getObjectStates(
 	constexpr double MAX_SCENARIO_TIME = 3600.0;
 	bool stopSimulation = false;
 	while (!stopSimulation) {
+		if (SE_GetQuitFlag() != 0) {
+			break;
+		}
+		
 		SE_StepDT(timeStep);
 		accumTime += timeStep;
 		for (int j = 0; j < SE_GetNumberOfObjects(); j++){


### PR DESCRIPTION
This fixes some of the issues where we get a simulation time of 3600.1 seconds. This works for when you set a stop trigger on the time in a scenario. I haven't tried on any other type of stop trigger yet, so I don't know if it works on them too.