### PR TITLE
Fix transformation monr

### DIFF
--- a/common/CRSTransformation.cpp
+++ b/common/CRSTransformation.cpp
@@ -30,7 +30,6 @@ CRSTransformation::CRSTransformation(const std::string &fromCRS, const std::stri
  * @brief Apply transformation from fromCRS to toCRS
  * 
  * @param traj reference to trajectory to transform
- * @return Eigen::Vector3d Transformed point
  */
 void CRSTransformation::apply(std::vector<ATOS::Trajectory::TrajectoryPoint> &trajPoints) {
 	// Put TrajPoints into array of PJ_POINTS
@@ -53,6 +52,20 @@ void CRSTransformation::apply(std::vector<ATOS::Trajectory::TrajectoryPoint> &tr
 		trajPoints[i].setYCoord(in[i].xyz.y);
 		trajPoints[i].setZCoord(in[i].xyz.z);
 	}
+}
+
+/**
+ * @brief Apply a transform on a point
+ * 
+ * @param point The point to transform
+ * @param direction Which direction to transform, e.g. PJ_FWD or PJ_INV
+ */
+void CRSTransformation::apply(geometry_msgs::msg::Point &point, PJ_DIRECTION direction) {
+	PJ_COORD in = proj_coord(point.x, point.y, point.z, 0);
+	PJ_COORD out = proj_trans(projection.get(), direction, in);
+	point.x = out.xyz.x;
+	point.y = out.xyz.y;
+	point.z = out.xyz.z;
 }
 
 /**

--- a/common/CRSTransformation.hpp
+++ b/common/CRSTransformation.hpp
@@ -8,6 +8,7 @@
 #include "proj.h"
 #include "trajectory.hpp"
 #include "rclcpp/logger.hpp"
+#include "geometry_msgs/msg/point.hpp"
 
 class CRSTransformation {
 
@@ -15,6 +16,7 @@ class CRSTransformation {
 
     CRSTransformation(const std::string &fromCRS, const std::string &toCRS);
     void apply(std::vector<ATOS::Trajectory::TrajectoryPoint> &traj);
+    void apply(geometry_msgs::msg::Point &point, PJ_DIRECTION direction);
     static std::vector<double> projToLLH(const std::string &projString, const std::string &datum);
     static void llhOffsetMeters(double *llh, const double *xyzOffset);
 

--- a/modules/EsminiAdapter/src/esminiadapter.cpp
+++ b/modules/EsminiAdapter/src/esminiadapter.cpp
@@ -367,7 +367,10 @@ void EsminiAdapter::reportObjectPosition(const Monitor::message_type::SharedPtr 
 	double roll, pitch, yaw;
 	m.getRPY(roll, pitch, yaw);
 
-	auto pos = monr->pose.pose.position;
+	geometry_msgs::msg::Point pos = monr->pose.pose.position;
+	if (me->applyTrajTransform) {
+		me->crsTransformation->apply(pos, PJ_INV);
+	}
 	auto speed = monr->velocity.twist.linear;
 
 	// Reporting to Esmini


### PR DESCRIPTION
We had problems with position triggers, where the issue was that the position from the MONR-data needed to be transformed back into the esmini coordinates in order to be at the correct position in esmini.

We also measured the speed for the transformation, it took about 10-30 microseconds for each transform, so I don't think it should be an issue when we have many objects.