### PR TITLE
Set maximum missing heartbeats from params.yaml

### DIFF
--- a/modules/ObjectControl/src/objectcontrol.cpp
+++ b/modules/ObjectControl/src/objectcontrol.cpp
@@ -53,7 +53,7 @@ ObjectControl::ObjectControl(std::shared_ptr<rclcpp::executors::MultiThreadedExe
 {
 	this->declare_parameter("max_missing_heartbeats", 100);
 	objectsConnectedTimer = create_wall_timer(1000ms, std::bind(&ObjectControl::publishObjectIds, this));
-  idClient = create_client<atos_interfaces::srv::GetObjectIds>(ServiceNames::getObjectIds);
+	idClient = create_client<atos_interfaces::srv::GetObjectIds>(ServiceNames::getObjectIds);
 	originClient = create_client<atos_interfaces::srv::GetTestOrigin>(ServiceNames::getTestOrigin);
 	trajectoryClient = create_client<atos_interfaces::srv::GetObjectTrajectory>(ServiceNames::getObjectTrajectory);
 	ipClient = create_client<atos_interfaces::srv::GetObjectIp>(ServiceNames::getObjectIp);

--- a/modules/ObjectControl/src/objectcontrol.cpp
+++ b/modules/ObjectControl/src/objectcontrol.cpp
@@ -51,8 +51,9 @@ ObjectControl::ObjectControl(std::shared_ptr<rclcpp::executors::MultiThreadedExe
 	connectedObjectIdsPub(*this),
 	stateChangePub(*this)
 {
+	this->declare_parameter("max_missing_heartbeats", 100);
 	objectsConnectedTimer = create_wall_timer(1000ms, std::bind(&ObjectControl::publishObjectIds, this));
-    idClient = create_client<atos_interfaces::srv::GetObjectIds>(ServiceNames::getObjectIds);
+  idClient = create_client<atos_interfaces::srv::GetObjectIds>(ServiceNames::getObjectIds);
 	originClient = create_client<atos_interfaces::srv::GetTestOrigin>(ServiceNames::getTestOrigin);
 	trajectoryClient = create_client<atos_interfaces::srv::GetObjectTrajectory>(ServiceNames::getObjectTrajectory);
 	ipClient = create_client<atos_interfaces::srv::GetObjectIp>(ServiceNames::getObjectIp);
@@ -644,7 +645,7 @@ void ObjectControl::notifyObjectsConnected() {
 void ObjectControl::connectToObject(
 		std::shared_ptr<TestObject> obj,
 		std::shared_future<void> &connStopReq) {
-	constexpr int maxConnHeabs = 100;
+	const int maxConnHeabs = this->get_parameter("max_missing_heartbeats").as_int();
 	constexpr int maxConnMonrs = 100;
 	try {
 		if (!obj->isConnected()) {


### PR DESCRIPTION
The parameter `max_missing_heartbeats` didn't change anything, but now it does. Added so `ObjectControl` reads this parameter.