### PR TITLE
Start timestamp update

### DIFF
--- a/atos/modules/OpenScenarioGateway/openscenariogateway.py
+++ b/atos/modules/OpenScenarioGateway/openscenariogateway.py
@@ -18,6 +18,7 @@ from typing import List
 
 ROOT_FOLDER_PATH_PARAMETER = "root_folder_path"
 ACTIVE_OBJECT_NAME_PARAMETER = "active_object_names"
+START_DELAY_PARAMETER = "start_delay_ms"
 SCENARIO_FILE_PARAMETER = "open_scenario_file"
 DEFAULT_FOLDER_PATH = path.expanduser("~/.astazero/ATOS/")
 
@@ -30,6 +31,7 @@ class ScenarioObject:
         self.catalog_ref: xosc.CatalogReference = catalog_ref
         self.ip: str = None
         self.started: bool = False
+        self.start_delay_ms = 0
 
 
 class OpenScenarioGateway(Node):
@@ -51,6 +53,7 @@ class OpenScenarioGateway(Node):
         self.declare_parameter(
             ACTIVE_OBJECT_NAME_PARAMETER, rclpy.Parameter.Type.STRING_ARRAY
         )
+        self.declare_parameter(START_DELAY_PARAMETER, 0)
         self.add_on_set_parameters_callback(self.parameter_callback)
 
         # ROS subscriptions/publishers
@@ -123,7 +126,11 @@ class OpenScenarioGateway(Node):
                 )
                 start_object_msg = atos_interfaces.msg.ObjectTriggerStart()
                 start_object_msg.id = object_id
-                start_object_msg.stamp = self.get_clock().now().to_msg()
+                start_delay_ms = self.get_parameter(START_DELAY_PARAMETER).value
+                start_object_msg.stamp.sec += int(time.time()) + start_delay_ms // 1000
+                start_object_msg.stamp.nanosec += (time.time_ns() % 1_000_000_000) + (
+                    start_delay_ms % 1000
+                ) * 1_000_000
                 self.start_object_pub_.publish(start_object_msg)
 
                 object.started = True

--- a/atos/modules/OpenScenarioGateway/openscenariogateway.py
+++ b/atos/modules/OpenScenarioGateway/openscenariogateway.py
@@ -31,7 +31,6 @@ class ScenarioObject:
         self.catalog_ref: xosc.CatalogReference = catalog_ref
         self.ip: str = None
         self.started: bool = False
-        self.start_delay_ms = 0
 
 
 class OpenScenarioGateway(Node):

--- a/conf/conf/atos-param-schema.json
+++ b/conf/conf/atos-param-schema.json
@@ -35,6 +35,11 @@
                     "type": "file",
                     "default": "GaragePlanScenario.xosc",
                     "description": "Name of the OpenSCENARIO-file. The file must end in .xosc and be located in the osc-directory."
+                },
+                "start_delay_ms": {
+                    "type": "int",
+                    "default": 0,
+                    "description": "Delay in milliseconds to add to the start time for the objects."
                 }
             }
         },

--- a/conf/conf/params.yaml
+++ b/conf/conf/params.yaml
@@ -9,6 +9,7 @@ atos:
     ros__parameters:
       open_scenario_file: "GaragePlanScenario.xosc"
       active_object_names: ["1"]
+      start_delay_ms: 0
   object_control:
     ros__parameters:
       max_missing_heartbeats: 100
@@ -28,17 +29,17 @@ atos:
         id: "ATOS"
         username: ""
         password: ""
-      mqtt2ros:             # Object specifying which MQTT topics to map to which ROS topics
-        mqtt_topics:        # Array specifying which ROS topics to bridge
-          - placeholder1     # The MQTT topic that should be bridged, corresponds to the sub-object in the YAML
+      mqtt2ros: # Object specifying which MQTT topics to map to which ROS topics
+        mqtt_topics: # Array specifying which ROS topics to bridge
+          - placeholder1 # The MQTT topic that should be bridged, corresponds to the sub-object in the YAML
         placeholder1:
           ros_topic: placeholder1 # ROS topic on which corresponding MQTT messages are published
-          advanced:         # Optional settings for each topic
+          advanced: # Optional settings for each topic
             mqtt:
-              qos: 1               # [0] MQTT QoS value
+              qos: 1 # [0] MQTT QoS value
             ros:
-              queue_size: 1        # [1] ROS publisher queue size
-      ros2mqtt:           # Object specifying which ROS topics to map to which MQTT topics
+              queue_size: 1 # [1] ROS publisher queue size
+      ros2mqtt: # Object specifying which ROS topics to map to which MQTT topics
         ros_topics:
           - placeholder2
         placeholder2:

--- a/docs/Usage/Modules/OpenScenarioGateway.md
+++ b/docs/Usage/Modules/OpenScenarioGateway.md
@@ -24,6 +24,7 @@ atos:
     ros__parameters:
       open_scenario_file: "scenario_name.xosc"     # The name of the scenario to open. Located in the ~/.astazero/ATOS/osc directory.
       active_object_names: ["object1", "object2"]  # List of object names to be active in the scenario. An empty list means all objects are active.
+      start_delay_ms: 0                            # Delay in milliseconds to add to all start commands sent to the objects.
 ```
 
 ## Using CustomCommandActions


### PR DESCRIPTION
This PR adds a parameter that can increase the timestamp in the STRT messages for delaying the start of the object. 

Note! This delay is added to all STRT msgs sent which needs to be accounted for when performing a scenario. 