### PR TITLE
Update esmini version

### DIFF
--- a/scripts/installation/install_deps.sh
+++ b/scripts/installation/install_deps.sh
@@ -105,7 +105,7 @@ if [ -d "/usr/local/include/esmini" ] && [ "$REINSTALL" = false ]; then
     echo "esmini already installed, skipping installation..."
 else
     echo "Downloading esmini binaries..."
-    wget https://github.com/esmini/esmini/releases/download/v2.37.13/esmini-bin_Linux.zip -O $SOURCE_PATH/esmini-bin_Linux.zip
+    wget https://github.com/esmini/esmini/releases/download/v2.37.17/esmini-bin_Linux.zip -O $SOURCE_PATH/esmini-bin_Linux.zip
     check_command_failed $? "Failed to get esmini."
     unzip $SOURCE_PATH/esmini-bin_Linux.zip -d $SOURCE_PATH/esmini-bin_Linux
     cd $SOURCE_PATH/esmini-bin_Linux

--- a/scripts/installation/requirements.txt
+++ b/scripts/installation/requirements.txt
@@ -2,5 +2,5 @@ pre-commit
 pyOpenSSL >= 23.2.0
 numpy<2.0
 scenariogeneration
-pytest>=7.0
-anyio>=3.6
+pytest>=6.2,<7.5
+anyio>=3.6,<4.0

--- a/scripts/installation/requirements.txt
+++ b/scripts/installation/requirements.txt
@@ -2,3 +2,5 @@ pre-commit
 pyOpenSSL >= 23.2.0
 numpy<2.0
 scenariogeneration
+pytest>=7.0
+anyio>=3.6


### PR DESCRIPTION
The version for esmini that was used is no longer on the release page: https://github.com/esmini/esmini/releases?page=3.

Changed to https://github.com/esmini/esmini/releases/tag/v2.37.17 instead.

Also updates versions in `requirements.txt`