### PR TITLE
ATOS install updates

### DIFF
--- a/scripts/installation/install_atos.sh
+++ b/scripts/installation/install_atos.sh
@@ -68,25 +68,34 @@ cd -
 ###### Configure setup scripts ######
 #####################################
 
+if [ -t 0 ] && [ -z "$DEBIAN_FRONTEND" ] && [ -z "$GITHUB_ACTION" ]; then
+    echo ""
+    echo "Would you like to add ATOS source lines to your shell config file (.bashrc/.zshrc)?"
+    echo "This will auto-activate the ATOS environment in new terminals. (y/n)"
+    read -r answer
+    if [ "$answer" == "${answer#[Yy]}" ]; then
+        echo "Skipping shell configuration."
+        exit 0
+    fi
+fi
+
 atos_venv_setup_script="source $ATOS_VENV_PATH/bin/activate"
 atos_python_site_packages="$(python -c 'import site; print(site.getsitepackages()[0])')"
 check_command_failed $? "Failed to determine ATOS Python site-packages path."
 atos_pythonpath_script="export PYTHONPATH=$atos_python_site_packages:\$PYTHONPATH"
-atos_setup_script="source $HOME/atos_ws/install/setup."
-ros2_setup_script="source /opt/ros/$ROS_DISTRO/setup."
 
 case "$SHELL" in
     */bash)
         add_source_line_if_needed $HOME/.bashrc "bash" "${atos_venv_setup_script}"
         add_source_line_if_needed $HOME/.bashrc "bash" "${atos_pythonpath_script}"
-        add_source_line_if_needed $HOME/.bashrc "bash" "${ros2_setup_script}"
-        add_source_line_if_needed $HOME/.bashrc "bash" "${atos_setup_script}"
+        add_source_line_if_needed $HOME/.bashrc "bash" "source /opt/ros/$ROS_DISTRO/setup.sh"
+        add_source_line_if_needed $HOME/.bashrc "bash" "source $HOME/atos_ws/install/setup.sh"
     ;;
     */zsh)
         add_source_line_if_needed $HOME/.zshrc "zsh" "${atos_venv_setup_script}"
         add_source_line_if_needed $HOME/.zshrc "zsh" "${atos_pythonpath_script}"
-        add_source_line_if_needed $HOME/.zshrc "zsh" "${ros2_setup_script}"
-        add_source_line_if_needed $HOME/.zshrc "zsh" "${atos_setup_script}"
+        add_source_line_if_needed $HOME/.zshrc "zsh" "source /opt/ros/$ROS_DISTRO/setup.zsh"
+        add_source_line_if_needed $HOME/.zshrc "zsh" "source $HOME/atos_ws/install/setup.zsh"
     ;;
     *)
         echo "Unsupported shell detected! Please use either bash or zsh shells to run ATOS"

--- a/scripts/installation/install_deps.sh
+++ b/scripts/installation/install_deps.sh
@@ -91,9 +91,9 @@ check_command_failed $? "Failed to install dependencies."
 if ! (apt list | grep -q "ros-$ROS_DISTRO-desktop"); then
     echo "Adding the ROS2 $ROS_DISTRO apt repository..."
 
-    # Install ROS2 prerequisites
+    # Install prerequisites for adding the ROS2 repository
     apt_update_retry
-    apt_install_retry lsb-release ros-dev-tools
+    apt_install_retry lsb-release curl
 
     # Authorize the ROS2 gpg key with apt
     sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
@@ -101,8 +101,12 @@ if ! (apt list | grep -q "ros-$ROS_DISTRO-desktop"); then
 
     # Add the ROS2 repo to sources list
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+    # Now install ros-dev-tools from the ROS2 repository
+    apt_update_retry
+    apt_install_retry ros-dev-tools
 else
-    echo "ROS2 $ROS_DISTRO" repository already added, skipping addition...
+    echo "ROS2 $ROS_DISTRO repository already added, skipping addition..."
 fi
 
 # Install ROS2 packages

--- a/scripts/installation/install_deps.sh
+++ b/scripts/installation/install_deps.sh
@@ -118,6 +118,11 @@ apt_install_retry \
     ros-${ROS_DISTRO}-launch-pytest
 check_command_failed $? "Failed to install ROS2 packages."
 
+# Initialize submodules so rosdep can find local packages like atos_interfaces
+if command -v git >/dev/null 2>&1 && git -C "${ATOS_REPO_PATH}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "${ATOS_REPO_PATH}" submodule update --init --recursive
+fi
+
 sudo rosdep init || true && \
     rosdep update || true && \
     rosdep install --from-paths ${ATOS_REPO_PATH} --ignore-src --rosdistro $ROS_DISTRO -y


### PR DESCRIPTION
Add updates to fix the install script:
- Moved order for downloads
- Fixed downloads of `atos_interfaces`
- Added option for not putting things in `.bashrc`/`.zshrc`